### PR TITLE
Resource PATCH support

### DIFF
--- a/bin/k8s-client
+++ b/bin/k8s-client
@@ -33,6 +33,8 @@ Options = Struct.new(
   :delete_stack,
   :api,
   :list_api_resources,
+  :patch_deployment,
+  :replicas,
 )
 
 options = Options.new()
@@ -142,6 +144,12 @@ parser = OptionParser.new do |parser|
   end
   parser.on('--list-api-resources') do
     options.list_api_resources = options.api
+  end
+  parser.on('--patch-deployment=NAME') do |name|
+    options.patch_deployment = name
+  end
+  parser.on('--replicas=COUNT', Integer) do |count|
+    options.replicas = count
   end
 end
 
@@ -298,4 +306,10 @@ elsif options.stack
   options.stack.apply(client,
     prune: options.prune_stack,
   )
+end
+
+if name = options.patch_deployment
+  client.api('apps/v1').resource('deployments', namespace: namespace).merge_patch(name, {
+      spec: { replicas: options.replicas },
+  })
 end

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -214,6 +214,26 @@ module K8s
     end
 
     # @return [Bool]
+    def patch?
+      @api_resource.verbs.include? 'patch'
+    end
+
+    # @param name [String]
+    # @param obj [Object] supporting to_json
+    # @param namespace [String]
+    # @param strategic_merge [Boolean] use kube Strategic Merge Patch instead of standard Merge Patch (arrays of objects are merged by name)
+    # @return [resource_class]
+    def merge_patch(name, obj, namespace: @namespace, strategic_merge: true)
+      @transport.request(
+        method: 'PATCH',
+        path: self.path(name, namespace: namespace),
+        content_type: strategic_merge ? 'application/strategic-merge-patch+json' : 'application/merge-patch+json',
+        request_object: obj,
+        response_class: @resource_class,
+      )
+    end
+
+    # @return [Bool]
     def delete?
       @api_resource.verbs.include? 'delete'
     end

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -102,7 +102,7 @@ module K8s
     end
 
     # @return [Hash]
-    def request_options(request_object: nil, **options)
+    def request_options(request_object: nil, content_type: 'application/json', **options)
       options[:headers] ||= {}
 
       if @auth_token
@@ -110,7 +110,7 @@ module K8s
       end
 
       if request_object
-        options[:headers]['Content-Type'] = 'application/json'
+        options[:headers]['Content-Type'] = content_type
         options[:body] = request_object.to_json
       end
 


### PR DESCRIPTION
`ResourceClient#merge_patch` defaulting to `Content-Type: application/strategic-merge-patch+json`, with support for plain `application/merge-patch+json` (roughly matching `Resource#merge`).