### PR TITLE
Support HTTP 503 => K8s::Error::ServiceUnavailable

### DIFF
--- a/lib/k8s/error.rb
+++ b/lib/k8s/error.rb
@@ -42,6 +42,7 @@ module K8s
     define_status_error 422, :Invalid
     define_status_error 429, :Timeout
     define_status_error 500, :InternalError
+    define_status_error 503, :ServiceUnavailable
     define_status_error 504, :ServerTimeout
   end
 end

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -167,6 +167,8 @@ module K8s
           status = K8s::API::MetaV1::Status.new(response_data)
 
           raise error_class.new(method, path, response.status, response.reason_phrase, status)
+        elsif response_data
+          raise error_class.new(method, path, response.status, "#{response.reason_phrase}: #{response_data}")
         else
           raise error_class.new(method, path, response.status, response.reason_phrase)
         end

--- a/spec/pharos/kube/transport_spec.rb
+++ b/spec/pharos/kube/transport_spec.rb
@@ -175,4 +175,21 @@ RSpec.describe K8s::Transport do
       end
     end
   end
+
+  context "for a 503 error" do
+    before do
+      stub_request(:get, 'localhost:8080/apis/metrics.k8s.io/v1beta1/nodes')
+        .to_return(
+          status: [503, "Service Unavailable"],
+          body: "Error: 'context canceled'\nTrying to reach: 'https://10.250.121.71:443/apis/metrics.k8s.io/v1beta1/nodes?labelSelector=k8s.kontena.io%2Fstack%3Dweave'",
+          headers: { 'Content-Type' => 'text/plain; charset=utf-8' }
+        )
+    end
+
+    describe '#get' do
+      it "raises ServiceUnavailable" do
+        expect{subject.get('/apis/metrics.k8s.io/v1beta1/nodes')}.to raise_error K8s::Error::ServiceUnavailable, %r(GET /apis/metrics.k8s.io/v1beta1/nodes => HTTP 503 Service Unavailable: Error: 'context canceled')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows transport to raise more informative `K8s::Error::ServiceUnavailable` errors on HTTP 503 responses. These can later be handled/retried in the code.