### PR TITLE
Fix APIClient#client_for_resource => raise K8s::Error::UndefinedResource handling

### DIFF
--- a/lib/k8s/api_client.rb
+++ b/lib/k8s/api_client.rb
@@ -57,7 +57,7 @@ module K8s
     # @return [K8s::ResourceClient]
     def resource(resource_name, namespace: nil)
       unless api_resource = api_resources.find{ |api_resource| api_resource.name == resource_name }
-        raise K8s::Error, "Unknown resource #{resource_name} for #{@api_version}"
+        raise K8s::Error::UndefinedResource, "Unknown resource #{resource_name} for #{@api_version}"
       end
 
       ResourceClient.new(@transport, self, api_resource,
@@ -67,15 +67,16 @@ module K8s
 
     # @param resource [K8s::Resource]
     # @param namespace [String, nil] default if resource is missing namespace
-    # @raise [K8s::Error] unknown resource
+    # @raise [K8s::Error::NotFound] API Group does not exist
+    # @raise [K8s::Error::UndefinedResource]
     # @return [K8s::ResourceClient]
     def client_for_resource(resource, namespace: nil)
       unless @api_version == resource.apiVersion
-        raise K8s::Error, "Invalid apiVersion=#{resource.apiVersion} for #{@api_version} client"
+        raise K8s::Error::UndefinedResource, "Invalid apiVersion=#{resource.apiVersion} for #{@api_version} client"
       end
 
       unless api_resource = api_resources.find{ |api_resource| api_resource.kind == resource.kind }
-        raise K8s::Error, "Unknown resource kind=#{resource.kind} for #{@api_version}"
+        raise K8s::Error::UndefinedResource, "Unknown resource kind=#{resource.kind} for #{@api_version}"
       end
 
       ResourceClient.new(@transport, self, api_resource,

--- a/lib/k8s/api_client.rb
+++ b/lib/k8s/api_client.rb
@@ -75,7 +75,7 @@ module K8s
       end
 
       unless api_resource = api_resources.find{ |api_resource| api_resource.kind == resource.kind }
-        raise K8s::Error, "Unknown resource kind=#{api_resource.kind} for #{@api_version}"
+        raise K8s::Error, "Unknown resource kind=#{resource.kind} for #{@api_version}"
       end
 
       ResourceClient.new(@transport, self, api_resource,

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -101,7 +101,8 @@ module K8s
 
     # @param resource [K8s::Resource]
     # @param namespace [String, nil] default if resource is missing namespace
-    # @raise [K8s::Error] unknown resource
+    # @raise [K8s::Error::NotFound] API Group does not exist
+    # @raise [K8s::Error::UndefinedResource]
     # @return [K8s::ResourceClient]
     def client_for_resource(resource, namespace: nil)
       api(resource.apiVersion).client_for_resource(resource, namespace: namespace)

--- a/lib/k8s/error.rb
+++ b/lib/k8s/error.rb
@@ -44,5 +44,9 @@ module K8s
     define_status_error 500, :InternalError
     define_status_error 503, :ServiceUnavailable
     define_status_error 504, :ServerTimeout
+
+    class UndefinedResource < Error
+
+    end
   end
 end

--- a/spec/pharos/kube/api_client_spec.rb
+++ b/spec/pharos/kube/api_client_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe K8s::APIClient do
 
     describe '#resource' do
       it "raises error for non-existing resource" do
-        expect{subject.resource('wtfs')}.to raise_error(K8s::Error, %r(Unknown resource wtfs for v1))
+        expect{subject.resource('wtfs')}.to raise_error(K8s::Error::UndefinedResource, %r(Unknown resource wtfs for v1))
       end
 
       it "returns client for resource name" do
@@ -99,7 +99,7 @@ RSpec.describe K8s::APIClient do
         }
 
         it "raises error" do
-          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error, %r(Invalid apiVersion=test/v1 for v1 client))
+          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error::UndefinedResource, %r(Invalid apiVersion=test/v1 for v1 client))
         end
       end
 
@@ -112,7 +112,7 @@ RSpec.describe K8s::APIClient do
         }
 
         it "raises error" do
-          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error,  %r(Unknown resource kind=Wtf for v1))
+          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error::UndefinedResource,  %r(Unknown resource kind=Wtf for v1))
         end
       end
     end

--- a/spec/pharos/kube/api_client_spec.rb
+++ b/spec/pharos/kube/api_client_spec.rb
@@ -81,11 +81,39 @@ RSpec.describe K8s::APIClient do
 
     describe '#resource' do
       it "raises error for non-existing resource" do
-        expect{subject.resource('wtfs')}.to raise_error(K8s::Error)
+        expect{subject.resource('wtfs')}.to raise_error(K8s::Error, %r(Unknown resource wtfs for v1))
       end
 
       it "returns client for resource name" do
         expect(subject.resource('pods').resource).to eq 'pods'
+      end
+    end
+
+    describe '#client_for_resource' do
+      context "for an invalid resource apiVersion" do
+        let(:resource) {
+          K8s::Resource.new(
+            apiVersion: 'test/v1',
+            kind: 'Test',
+          )
+        }
+
+        it "raises error" do
+          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error, %r(Invalid apiVersion=test/v1 for v1 client))
+        end
+      end
+
+      context "for an invalid resource kind" do
+        let(:resource) {
+          K8s::Resource.new(
+            apiVersion: 'v1',
+            kind: 'Wtf',
+          )
+        }
+
+        it "raises error" do
+          expect{subject.client_for_resource(resource)}.to raise_error(K8s::Error,  %r(Unknown resource kind=Wtf for v1))
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #16

The `raise K8s::Error::UndefinedResource` is the only explicitly raised error case in the k8s-client codebase, apart from the API errors raised by the transport, so it makes sense to type that error.