### PR TITLE
Fix Client to query multiple API group versions

### DIFF
--- a/bin/k8s-client
+++ b/bin/k8s-client
@@ -10,6 +10,7 @@ Options = Struct.new(
   :server,
   :insecure_skip_tls_verify,
   :prefetch_resources,
+  :list_resource_kinds,
   :namespace,
   :all_namespaces,
   :label_selector,
@@ -75,6 +76,9 @@ parser = OptionParser.new do |parser|
   end
   parser.on('--prefetch-resources', TrueClass) do |bool|
     options.prefetch_resources = bool
+  end
+  parser.on('--list-resource-kinds', TrueClass) do |bool|
+    options.list_resource_kinds = true
   end
   parser.on('-n', '--namespace=NAMESPACE') do |namespace|
     options.namespace = namespace
@@ -169,6 +173,14 @@ logger.info "Kube server version: #{client.version.gitVersion}"
 
 if options.prefetch_resources
   client.apis(prefetch_resources: true)
+end
+
+if options.list_resource_kinds
+  client.resources.sort_by{|r| r.kind}.each do |resource_client|
+    next if resource_client.subresource?
+    
+    puts "#{resource_client.kind} => #{resource_client.api_version} #{resource_client.name}"
+  end
 end
 
 if options.all_namespaces

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -48,7 +48,7 @@ module K8s
     def api_groups!
       @api_groups = @transport.get('/apis',
         response_class: K8s::API::MetaV1::APIGroupList,
-      ).groups.map{|api_group| api_group.preferredVersion.groupVersion }
+      ).groups.map{|api_group| api_group.versions.map{|api_version| api_version.groupVersion} }.flatten
     end
 
     # Cached /apis preferred group apiVersions

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -94,6 +94,11 @@ module K8s
       @resource
     end
 
+    # @return [Boolean]
+    def subresource?
+      !!@subresource
+    end
+
     # @return [String, nil]
     def subresource
       @subresource

--- a/spec/fixtures/apis/apiextensions.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/apiextensions.k8s.io-v1beta1.json
@@ -29,6 +29,8 @@
       "namespaced": false,
       "kind": "CustomResourceDefinition",
       "verbs": [
+        "get",
+        "patch",
         "update"
       ]
     }

--- a/spec/fixtures/apis/apiregistration.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/apiregistration.k8s.io-v1beta1.json
@@ -1,7 +1,7 @@
 {
   "kind": "APIResourceList",
   "apiVersion": "v1",
-  "groupVersion": "apiregistration.k8s.io/v1",
+  "groupVersion": "apiregistration.k8s.io/v1beta1",
   "resources": [
     {
       "name": "apiservices",

--- a/spec/fixtures/apis/apps-v1beta1.json
+++ b/spec/fixtures/apis/apps-v1beta1.json
@@ -1,0 +1,124 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "apps/v1beta1",
+  "resources": [
+    {
+      "name": "controllerrevisions",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ControllerRevision",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "deployments",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Deployment",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "deploy"
+      ],
+      "categories": [
+        "all"
+      ]
+    },
+    {
+      "name": "deployments/rollback",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DeploymentRollback",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "deployments/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "deployments/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Deployment",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "statefulsets",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "StatefulSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "sts"
+      ],
+      "categories": [
+        "all"
+      ]
+    },
+    {
+      "name": "statefulsets/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "statefulsets/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "StatefulSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/apis/apps-v1beta2.json
+++ b/spec/fixtures/apis/apps-v1beta2.json
@@ -1,0 +1,194 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "apps/v1beta2",
+  "resources": [
+    {
+      "name": "controllerrevisions",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ControllerRevision",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "daemonsets",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DaemonSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ds"
+      ],
+      "categories": [
+        "all"
+      ]
+    },
+    {
+      "name": "daemonsets/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DaemonSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "deployments",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Deployment",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "deploy"
+      ],
+      "categories": [
+        "all"
+      ]
+    },
+    {
+      "name": "deployments/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1beta2",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "deployments/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Deployment",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "replicasets",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ReplicaSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "rs"
+      ],
+      "categories": [
+        "all"
+      ]
+    },
+    {
+      "name": "replicasets/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1beta2",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "replicasets/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ReplicaSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "statefulsets",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "StatefulSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "sts"
+      ],
+      "categories": [
+        "all"
+      ]
+    },
+    {
+      "name": "statefulsets/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "apps",
+      "version": "v1beta2",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "statefulsets/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "StatefulSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/apis/authentication.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/authentication.k8s.io-v1beta1.json
@@ -1,0 +1,16 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "authentication.k8s.io/v1beta1",
+  "resources": [
+    {
+      "name": "tokenreviews",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "TokenReview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/apis/authorization.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/authorization.k8s.io-v1beta1.json
@@ -1,0 +1,43 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "authorization.k8s.io/v1beta1",
+  "resources": [
+    {
+      "name": "localsubjectaccessreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "LocalSubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "selfsubjectaccessreviews",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "SelfSubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "selfsubjectrulesreviews",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "SelfSubjectRulesReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "subjectaccessreviews",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "SubjectAccessReview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/apis/autoscaling-v2beta1.json
+++ b/spec/fixtures/apis/autoscaling-v2beta1.json
@@ -1,13 +1,13 @@
 {
   "kind": "APIResourceList",
   "apiVersion": "v1",
-  "groupVersion": "apiregistration.k8s.io/v1",
+  "groupVersion": "autoscaling/v2beta1",
   "resources": [
     {
-      "name": "apiservices",
+      "name": "horizontalpodautoscalers",
       "singularName": "",
-      "namespaced": false,
-      "kind": "APIService",
+      "namespaced": true,
+      "kind": "HorizontalPodAutoscaler",
       "verbs": [
         "create",
         "delete",
@@ -17,13 +17,19 @@
         "patch",
         "update",
         "watch"
+      ],
+      "shortNames": [
+        "hpa"
+      ],
+      "categories": [
+        "all"
       ]
     },
     {
-      "name": "apiservices/status",
+      "name": "horizontalpodautoscalers/status",
       "singularName": "",
-      "namespaced": false,
-      "kind": "APIService",
+      "namespaced": true,
+      "kind": "HorizontalPodAutoscaler",
       "verbs": [
         "get",
         "patch",

--- a/spec/fixtures/apis/batch-v1beta1.json
+++ b/spec/fixtures/apis/batch-v1beta1.json
@@ -1,13 +1,13 @@
 {
   "kind": "APIResourceList",
   "apiVersion": "v1",
-  "groupVersion": "apiregistration.k8s.io/v1",
+  "groupVersion": "batch/v1beta1",
   "resources": [
     {
-      "name": "apiservices",
+      "name": "cronjobs",
       "singularName": "",
-      "namespaced": false,
-      "kind": "APIService",
+      "namespaced": true,
+      "kind": "CronJob",
       "verbs": [
         "create",
         "delete",
@@ -17,13 +17,19 @@
         "patch",
         "update",
         "watch"
+      ],
+      "shortNames": [
+        "cj"
+      ],
+      "categories": [
+        "all"
       ]
     },
     {
-      "name": "apiservices/status",
+      "name": "cronjobs/status",
       "singularName": "",
-      "namespaced": false,
-      "kind": "APIService",
+      "namespaced": true,
+      "kind": "CronJob",
       "verbs": [
         "get",
         "patch",

--- a/spec/fixtures/apis/certificates.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/certificates.k8s.io-v1beta1.json
@@ -37,6 +37,8 @@
       "namespaced": false,
       "kind": "CertificateSigningRequest",
       "verbs": [
+        "get",
+        "patch",
         "update"
       ]
     }

--- a/spec/fixtures/apis/rbac.authorization.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/rbac.authorization.k8s.io-v1beta1.json
@@ -1,0 +1,71 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "rbac.authorization.k8s.io/v1beta1",
+  "resources": [
+    {
+      "name": "clusterrolebindings",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "ClusterRoleBinding",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "clusterroles",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "ClusterRole",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "rolebindings",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "RoleBinding",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "roles",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Role",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/apis/storage.k8s.io-v1beta1.json
+++ b/spec/fixtures/apis/storage.k8s.io-v1beta1.json
@@ -1,13 +1,13 @@
 {
   "kind": "APIResourceList",
   "apiVersion": "v1",
-  "groupVersion": "apiregistration.k8s.io/v1",
+  "groupVersion": "storage.k8s.io/v1beta1",
   "resources": [
     {
-      "name": "apiservices",
+      "name": "storageclasses",
       "singularName": "",
       "namespaced": false,
-      "kind": "APIService",
+      "kind": "StorageClass",
       "verbs": [
         "create",
         "delete",
@@ -17,17 +17,25 @@
         "patch",
         "update",
         "watch"
+      ],
+      "shortNames": [
+        "sc"
       ]
     },
     {
-      "name": "apiservices/status",
+      "name": "volumeattachments",
       "singularName": "",
       "namespaced": false,
-      "kind": "APIService",
+      "kind": "VolumeAttachment",
       "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
         "get",
+        "list",
         "patch",
-        "update"
+        "update",
+        "watch"
       ]
     }
   ]


### PR DESCRIPTION
Fixes #18 stack prune for `CronJob`

`Client#api_groups` now returns *all*  API group versions, not just the preferred API group version.