### PR TITLE
Allow overriding server/options for K8s::Client.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ The keyword options are [Excon](https://github.com/excon/excon/) options.
 client = K8s::Client.config(K8s::Config.load_file('~/.kube/config'))
 ```
 
+##### With overrides
+
+```ruby
+client = K8s::Client.config(K8s::Config.load_file('~/.kube/config'),
+  server: 'http://localhost:8001',
+)
+```
+
 #### In-cluster client from pod envs/secrets
 
 ```ruby

--- a/bin/k8s-client
+++ b/bin/k8s-client
@@ -69,10 +69,10 @@ parser = OptionParser.new do |parser|
     options.config = K8s::Config.load_file(path)
   end
   parser.on('--server=SERVER') do |server|
-    options.server = URI(server)
+    options.server = server
   end
-  parser.on('--insecure-skip-tls-verify') do
-    options.insecure_skip_tls_verify = true
+  parser.on('--insecure-skip-tls-verify', TrueClass) do |bool|
+    options.insecure_skip_tls_verify = bool
   end
   parser.on('--prefetch-resources', TrueClass) do |bool|
     options.prefetch_resources = bool
@@ -160,11 +160,17 @@ end
 parser.parse!
 
 if options.config
-  client = K8s::Client.config(options.config)
+  overrides = {}
+  overrides[:ssl_verify_peer] = false if options.insecure_skip_tls_verify
+
+  client = K8s::Client.config(options.config,
+    server: options.server,
+    **overrides
+  )
 elsif options.in_cluster_config
   client = K8s::Client.in_cluster_config
 else
-  client = K8s.client(options.server.to_s,
+  client = K8s.client(options.server,
     ssl_verify_peer: !options.insecure_skip_tls_verify,
   )
 end
@@ -178,7 +184,7 @@ end
 if options.list_resource_kinds
   client.resources.sort_by{|r| r.kind}.each do |resource_client|
     next if resource_client.subresource?
-    
+
     puts "#{resource_client.kind} => #{resource_client.api_version} #{resource_client.name}"
   end
 end

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -10,8 +10,10 @@ module K8s
   class Client
     # @param config [Phraos::Kube::Config]
     # @return [K8s::Client]
-    def self.config(config)
-      new(Transport.config(config))
+    def self.config(config, namespace: nil, **options)
+      new(Transport.config(config, **options),
+        namespace: namespace,
+      )
     end
 
     # @return [K8s::Client]

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -20,8 +20,10 @@ module K8s
     #
     # @param config [Phraos::Kube::Config]
     # @return [K8s::Transport]
-    def self.config(config)
+    def self.config(config, server: nil, **overrides)
       options = {}
+
+      server ||= config.cluster.server
 
       if config.cluster.insecure_skip_tls_verify
         logger.debug "Using config with .cluster.insecure_skip_tls_verify"
@@ -56,9 +58,9 @@ module K8s
         options[:client_key_data] = Base64.decode64(key_data)
       end
 
-      logger.info "Using config with server=#{config.cluster.server}"
+      logger.info "Using config with server=#{server}"
 
-      new(config.cluster.server, **options)
+      new(server, **options, **overrides)
     end
 
     # In-cluster config within a kube pod, using the kubernetes service envs and serviceaccount secrets

--- a/spec/pharos/kube/transport_spec.rb
+++ b/spec/pharos/kube/transport_spec.rb
@@ -22,6 +22,32 @@ RSpec.describe K8s::Transport do
       it 'uses an ssl_cert_store that verifies the server cert' do
         expect(subject.options[:ssl_cert_store].verify(server_cert)).to eq true
       end
+
+      context "overriding the server option" do
+        subject {
+          described_class.config(K8s::Config.load_file(fixture_path('config/kubeadm-admin.conf')),
+            server: 'http://localhost:8001',
+          )
+        }
+
+        it "uses the overriden server" do
+          expect(subject.server).to eq 'http://localhost:8001'
+        end
+      end
+
+      context "overriding other options" do
+        subject {
+          described_class.config(K8s::Config.load_file(fixture_path('config/kubeadm-admin.conf')),
+            ssl_verify_peer: false,
+          )
+        }
+
+        it "uses the overriden server" do
+          expect(subject.options).to match hash_including(
+            ssl_verify_peer: false,
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Allow overriding the `server` and other options loaded from the `K8s::Config`.