### PR TITLE
Fix missing K8s::Config default values

### DIFF
--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -83,7 +83,7 @@ module K8s
 
     attribute :kind, Types::Strict::String.optional.default(nil)
     attribute :apiVersion, Types::Strict::String.optional.default(nil)
-    attribute :preferences, Types::Strict::Hash.optional
+    attribute :preferences, Types::Strict::Hash.optional.default(nil)
     attribute :clusters, Types::Strict::Array.of(NamedCluster)
     attribute :users, Types::Strict::Array.of(NamedUser)
     attribute :contexts, Types::Strict::Array.of(NamedContext)

--- a/spec/k8s/config_spec.rb
+++ b/spec/k8s/config_spec.rb
@@ -31,4 +31,42 @@ RSpec.describe K8s::Config do
       end
     end
   end
+
+  it 'does not require optional params' do
+    subject = described_class.new(
+      clusters: [
+        {
+          name: 'kubernetes',
+          cluster: {
+            server: 'http://localhost:8080',
+            certificate_authority: 'ca.pem',
+
+          }
+        }
+      ],
+      users: [
+        {
+          name: 'test',
+          user: {
+            token: 'SECRET',
+          }
+        }
+      ],
+
+      contexts: [
+        {
+          name: 'test',
+          context: {
+            cluster: 'kubernetes',
+            user: 'test'
+          }
+        }
+      ],
+      current_context: 'test'
+    )
+
+    expect(subject.context.cluster).to eq 'kubernetes'
+    expect(subject.cluster.server).to eq 'http://localhost:8080'
+    expect(subject.user.token).to eq 'SECRET'
+  end
 end


### PR DESCRIPTION
Relevant when constructing `K8s::Config.new(...)` manually, but possibly also if loading some old kubeconfig from before `preferences` were added.