### PR TITLE
Fix K8s::Transport.config to support token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ The keyword options are [Excon](https://github.com/excon/excon/) options.
 client = K8s::Client.config(K8s::Config.load_file('~/.kube/config'))
 ```
 
+#### Supported kubeconfig options
+
+Not all kubeconfig options are supported, only the following kubeconfig options work:
+
+* `current-context`
+* `context.cluster`
+* `context.user`
+* `cluster.server`
+* `cluster.insecure_skip_tls_verify`
+* `cluster.certificate_authority`
+* `cluster.certificate_authority_data`
+* `user.client_certificate` + `user.client_key`
+* `user.client_certificate_data` + `user.client_key_data`
+* `user.token`
+
 ##### With overrides
 
 ```ruby

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -63,6 +63,12 @@ module K8s
         options[:client_key_data] = Base64.decode64(key_data)
       end
 
+      if token = config.user.token
+        logger.debug "Using config with .user.token=..."
+
+        options[:auth_token] = token
+      end
+
       logger.info "Using config with server=#{server}"
 
       new(server, **options, **overrides)


### PR DESCRIPTION
Fixes #28

Also documents supported kubeconfig options in the `README`