### PR TITLE
Fix stack prune to skip forbidden resource types

### DIFF
--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -116,9 +116,9 @@ module K8s
     end
 
     # Delete all stack resources that were not applied
-    def prune(client, keep_resources: )
+    def prune(client, keep_resources: , skip_forbidden: true)
       # using skip_forbidden: assume we can't create resource types that we are forbidden to list, so we don't need to prune them either
-      client.list_resources(labelSelector: {@label => name}, skip_forbidden: true).each do |resource|
+      client.list_resources(labelSelector: {@label => name}, skip_forbidden: skip_forbidden).each do |resource|
         next if PRUNE_IGNORE.include? "#{resource.apiVersion}:#{resource.kind}"
 
         resource_label = resource.metadata.labels ? resource.metadata.labels[@label] : nil

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -117,7 +117,8 @@ module K8s
 
     # Delete all stack resources that were not applied
     def prune(client, keep_resources: )
-      client.list_resources(labelSelector: {@label => name}).each do |resource|
+      # using skip_forbidden: assume we can't create resource types that we are forbidden to list, so we don't need to prune them either
+      client.list_resources(labelSelector: {@label => name}, skip_forbidden: true).each do |resource|
         next if PRUNE_IGNORE.include? "#{resource.apiVersion}:#{resource.kind}"
 
         resource_label = resource.metadata.labels ? resource.metadata.labels[@label] : nil

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -224,10 +224,11 @@ module K8s
 
     # @param options [Array<Hash>] @see #request
     # @param skip_missing [Boolean] return nil for HTTP 404 responses
+    # @param skip_forbidden [Boolean] return nil for HTTP 403 responses
     # @param retry_errors [Boolean] retry with non-pipelined request for HTTP 503 responses
     # @param common_options [Hash] @see #request, merged with the per-request options
     # @return [Array<response_class, Hash, nil>]
-    def requests(*options, skip_missing: false, retry_errors: true, **common_options)
+    def requests(*options, skip_missing: false, skip_forbidden: false, retry_errors: true, **common_options)
       return [] if options.empty? # excon chokes
 
       start = Time.now
@@ -245,6 +246,12 @@ module K8s
           )
         rescue K8s::Error::NotFound
           if skip_missing
+            nil
+          else
+            raise
+          end
+        rescue K8s::Error::Forbidden
+          if skip_forbidden
             nil
           else
             raise

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -377,6 +377,49 @@ RSpec.describe K8s::Client do
           ])).to eq [service_resource]
         end
       end
+
+      context "with partial 403 errors" do
+        before do
+          stub_request(:get, 'localhost:8080/api/v1/services')
+            .to_return(
+              status: 200,
+              headers: { 'Content-Type' => 'application/json' },
+              body: {
+                apiVersion: 'v1',
+                kind: 'ServiceList',
+                metadata: {},
+                items: [service_resource],
+              }.to_json,
+            )
+          stub_request(:get, 'localhost:8080/api/v1/configmaps')
+            .to_return(
+              status: [403, "Forbidden"],
+              body: fixture('api/error-forbidden.json'),
+              headers: { 'Content-Type' => 'application/json' }
+            )
+        end
+
+        it "raises Forbidden" do
+          expect{
+            subject.list_resources([
+              subject.api('v1').resource('services'),
+              subject.api('v1').resource('configmaps'),
+            ])
+          }.to raise_error(K8s::Error::Forbidden)
+        end
+
+        describe 'skip_forbidden: true' do
+          it "returns existing resources" do
+            expect(subject.list_resources(
+              [
+                subject.api('v1').resource('services'),
+                subject.api('v1').resource('configmaps'),
+              ],
+              skip_forbidden: true,
+            )).to eq [service_resource]
+          end
+        end
+      end
     end
   end
 end

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -340,5 +340,43 @@ RSpec.describe K8s::Client do
         end
       end
     end
+
+    describe '#list_resources' do
+      let(:service_resource) { K8s::Resource.from_file(fixture_path('resources/service-foo.yaml')) }
+
+      context "which partially have resources" do
+        before do
+          stub_request(:get, 'localhost:8080/api/v1/services')
+            .to_return(
+              status: 200,
+              headers: { 'Content-Type' => 'application/json' },
+              body: {
+                apiVersion: 'v1',
+                kind: 'ServiceList',
+                metadata: {},
+                items: [service_resource],
+              }.to_json,
+            )
+          stub_request(:get, 'localhost:8080/api/v1/configmaps')
+            .to_return(
+              status: 200,
+              headers: { 'Content-Type' => 'application/json' },
+              body: {
+                apiVersion: 'v1',
+                kind: 'ConfgiMapList',
+                metadata: {},
+                items: [],
+              }.to_json,
+            )
+        end
+
+        it "returns existing resources" do
+          expect(subject.list_resources([
+            subject.api('v1').resource('services'),
+            subject.api('v1').resource('configmaps'),
+          ])).to eq [service_resource]
+        end
+      end
+    end
   end
 end

--- a/spec/k8s/stack_spec.rb
+++ b/spec/k8s/stack_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe K8s::Stack do
 
       before do
         allow(client).to receive(:get_resources).with([K8s::Resource, K8s::Resource, K8s::Resource]).and_return([nil, nil, nil ])
-        allow(client).to receive(:list_resources).with(labelSelector: { 'k8s.kontena.io/stack' => 'whoami' }).and_return(resources)
+        allow(client).to receive(:list_resources).with(labelSelector: { 'k8s.kontena.io/stack' => 'whoami' }, skip_forbidden: true).and_return(resources)
       end
 
       it "creates the resource with the correct label" do

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -350,5 +350,88 @@ RSpec.describe K8s::Transport do
         expect(result).to match [Hash, nil]
       end
     end
+
+    context "with HTTP 403 responses" do
+      before do
+        stub_request(:get, 'localhost:8080/api/v1/namespaces/default/services/foo')
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: fixture('api/services-foo.json'),
+          )
+        stub_request(:get, 'localhost:8080/api/v1/namespaces/default/configmaps/bar')
+          .to_return(
+            status: [403, "Forbidden"],
+            body: fixture('api/error-forbidden.json'),
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it "raises Forbidden" do
+        expect{
+          subject.gets(
+            '/api/v1/namespaces/default/services/foo',
+            '/api/v1/namespaces/default/configmaps/bar',
+            skip_missing: true,
+          )
+        }.to raise_error(K8s::Error::Forbidden)
+      end
+    end
+  end
+
+  describe 'skip_forbidden: true' do
+    context "with HTTP 403 responses" do
+      before do
+        stub_request(:get, 'localhost:8080/api/v1/namespaces/default/services/foo')
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: fixture('api/services-foo.json'),
+          )
+        stub_request(:get, 'localhost:8080/api/v1/namespaces/default/configmaps/bar')
+          .to_return(
+            status: [403, "Forbidden"],
+            body: fixture('api/error-forbidden.json'),
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it "returns mixed resources and nils" do
+        result = subject.gets(
+          '/api/v1/namespaces/default/services/foo',
+          '/api/v1/namespaces/default/configmaps/bar',
+          skip_forbidden: true,
+        )
+
+        expect(result).to match [Hash, nil]
+      end
+    end
+
+    context "with HTTP 404 responses" do
+      before do
+        stub_request(:get, 'localhost:8080/api/v1/namespaces/default/services/foo')
+          .to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: fixture('api/services-foo.json'),
+          )
+        stub_request(:get, 'localhost:8080/api/v1/namespaces/default/configmaps/bar')
+          .to_return(
+            status: 404,
+            headers: { 'Content-Type' => 'application/json' },
+            body: fixture('api/configmaps-bar-404.json'),
+          )
+      end
+
+      it "raises NotFound" do
+        expect{
+          subject.gets(
+            '/api/v1/namespaces/default/services/foo',
+            '/api/v1/namespaces/default/configmaps/bar',
+            skip_forbidden: true,
+          )
+        }.to raise_error(K8s::Error::NotFound)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #30

Have `K8s::Stack#prune` => `K8s::Client#list_resources` skip any HTTP 403 errors for the list requests. If we don't have permission to list a resource type, then it's unlikely that we would have created any stack resources within that type to prune.

If you update a stack to remove some resource type, then you still need to leave `verbs: ["list", "delete"]` permissions for the deploying role in order to prune those resources when upgrading.