### PR TITLE
Fix resource default namespacing

### DIFF
--- a/bin/k8s-client
+++ b/bin/k8s-client
@@ -165,6 +165,7 @@ if options.config
 
   client = K8s::Client.config(options.config,
     server: options.server,
+    namespace: options.namespace,
     **overrides
   )
 elsif options.in_cluster_config
@@ -172,6 +173,7 @@ elsif options.in_cluster_config
 else
   client = K8s.client(options.server,
     ssl_verify_peer: !options.insecure_skip_tls_verify,
+    namespace: options.namespace,
   )
 end
 

--- a/lib/k8s/api_client.rb
+++ b/lib/k8s/api_client.rb
@@ -11,7 +11,6 @@ module K8s
       else
         File.join('/api', api_version)
       end
-
     end
 
     # @param transport [K8s::Transport]
@@ -73,7 +72,7 @@ module K8s
     end
 
     # @param resource [K8s::Resource]
-    # @param namespace [String, nil] default if resource is missing namespace
+    # @param namespace [String, nil] default if resource is missing namespace, ignored for non-namespaced resources
     # @raise [K8s::Error::NotFound] API Group does not exist
     # @raise [K8s::Error::UndefinedResource]
     # @return [K8s::ResourceClient]
@@ -86,8 +85,11 @@ module K8s
         raise K8s::Error::UndefinedResource, "Unknown resource kind=#{resource.kind} for #{@api_version}"
       end
 
+      resource_namespace = resource.metadata.namespace
+      resource_namespace ||= namespace if api_resource.namespaced
+
       ResourceClient.new(@transport, self, api_resource,
-        namespace: resource.metadata.namespace || namespace,
+        namespace: resource_namespace,
       )
     end
 

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -18,6 +18,8 @@ module K8s
     # @param options [Hash] @see Transport.config
     # @return [K8s::Client]
     def self.config(config, namespace: nil, **options)
+      namespace ||= config.context.namespace
+
       new(Transport.config(config, **options),
         namespace: namespace,
       )

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -137,7 +137,7 @@ module K8s
     #
     # @param resources [Array<K8s::Resource>]
     # @return [Array<K8s::Resource, nil>] matching resources array 1:1
-    def get_resources(resources)
+    def get_resources(resources, namespace: @namespace)
       # prefetch api resources, skip missing APIs
       resource_apis = apis(resources.map{ |resource| resource.apiVersion }, prefetch_resources: true, skip_missing: true)
 
@@ -145,11 +145,11 @@ module K8s
       requests = resources.zip(resource_apis).map{ |resource, api_client|
         next nil unless api_client.api_resources?
 
-        resource_client = api_client.client_for_resource(resource)
+        resource_client = api_client.client_for_resource(resource, namespace: namespace)
 
         {
           method: 'GET',
-          path: resource_client.path(resource.metadata.name, namespace: resource.metadata.namespace),
+          path: resource_client.path(resource.metadata.name),
           response_class: resource_client.resource_class,
         }
       }

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -114,7 +114,7 @@ module K8s
     # @raise [K8s::Error::NotFound] API Group does not exist
     # @raise [K8s::Error::UndefinedResource]
     # @return [K8s::ResourceClient]
-    def client_for_resource(resource, namespace: nil)
+    def client_for_resource(resource, namespace: @namespace)
       api(resource.apiVersion).client_for_resource(resource, namespace: namespace)
     end
 

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -60,6 +60,9 @@ module K8s
       resources.zip(api_lists).map {|resource, api_list| api_list ? resource.process_list(api_list) : [] }.flatten
     end
 
+    # equivalent to an empty namespace
+    DEFAULT_NAMESPACE = 'default'
+
     # @param transport [K8s::Transport]
     # @param api_client [K8s::APIClient]
     # @param api_resource [K8s::API::MetaV1::APIResource]
@@ -147,9 +150,12 @@ module K8s
     # @param resource [resource_class] with metadata.namespace and metadata.name set
     # @return [resource_class]
     def create_resource(resource)
+      namespace = resource.metadata.namespace
+      namespace ||= @namespace || DEFAULT_NAMESPACE if namespaced?
+
       @transport.request(
         method: 'POST',
-        path: self.path(namespace: resource.metadata.namespace),
+        path: self.path(namespace: namespace),
         request_object: resource,
         response_class: @resource_class,
       )

--- a/spec/fixtures/resources/namespace.yaml
+++ b/spec/fixtures/resources/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/spec/fixtures/resources/service-bar-nonamespace.yaml
+++ b/spec/fixtures/resources/service-bar-nonamespace.yaml
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: whoami
+  name: bar
   labels:
-    app: whoami
+    app: test
 spec:
   selector:
-    app: whoami
+    app: test
   ports:
     - port: 80
-      protocol: TCP
-      targetPort: 8000

--- a/spec/fixtures/resources/service-nonamespace.yaml
+++ b/spec/fixtures/resources/service-nonamespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  labels:
+    app: whoami
+spec:
+  selector:
+    app: whoami
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8000

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe K8s::Client do
       subject { described_class.config(config) }
 
       describe '#client_for_resource' do
-        let(:resource) { resource_fixture('resources/service-nonamespace.yaml') }
+        let(:resource) { resource_fixture('resources/service-bar-nonamespace.yaml') }
 
         it "uses the configured namespace as the default" do
           expect(subject.client_for_resource(resource).namespace).to eq 'test'
@@ -241,7 +241,7 @@ RSpec.describe K8s::Client do
       end
 
       context "for a service resource without a namespace" do
-        let(:resource) { resource_fixture('resources/service-nonamespace.yaml') }
+        let(:resource) { resource_fixture('resources/service-bar-nonamespace.yaml') }
         let(:server_resource) { resource.merge(
           metadata: {
             namespace: 'default',
@@ -269,7 +269,7 @@ RSpec.describe K8s::Client do
             expect(r).to match K8s::Resource
             expect(r.kind).to eq 'Service'
             expect(r.metadata.namespace).to eq 'default'
-            expect(r.metadata.name).to eq 'whoami'
+            expect(r.metadata.name).to eq 'bar'
             expect(r.metadata.resourceVersion).to eq '1'
           end
         end
@@ -303,7 +303,7 @@ RSpec.describe K8s::Client do
             expect(r).to match K8s::Resource
             expect(r.kind).to eq 'Service'
             expect(r.metadata.namespace).to eq 'test'
-            expect(r.metadata.name).to eq 'whoami'
+            expect(r.metadata.name).to eq 'bar'
             expect(r.metadata.resourceVersion).to eq '1'
           end
         end

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -310,6 +310,8 @@ RSpec.describe K8s::Client do
       end
 
       context "for a namespace resource" do
+        subject { described_class.new(transport, namespace: 'test') }
+
         let(:resource) { resource_fixture('resources/namespace.yaml') }
         let(:server_resource) { resource.merge(
           metadata: { resourceVersion: '1'}

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -117,6 +117,52 @@ RSpec.describe K8s::Client do
       end
     end
 
+    describe '#config' do
+      let(:config_context) {
+        {
+          cluster: 'kubernetes',
+          user: 'test',
+          namespace: 'test',
+        }
+      }
+
+      let(:config) { K8s::Config.new(
+        clusters: [
+          {
+            name: 'kubernetes',
+            cluster: {
+              server: 'http://localhost:8080',
+            }
+          }
+        ],
+        users: [
+          {
+            name: 'test',
+            user: {
+            }
+          }
+        ],
+
+        contexts: [
+          {
+            name: 'test',
+            context: config_context,
+          }
+        ],
+        current_context: 'test'
+      ) }
+
+      subject { described_class.config(config) }
+
+      describe '#client_for_resource' do
+        let(:resource) { resource_fixture('resources/service-nonamespace.yaml') }
+
+        it "uses the configured namespace as the default" do
+          expect(subject.client_for_resource(resource).namespace).to eq 'test'
+        end
+      end
+    end
+
     describe '#version' do
       it "returns version" do
         expect(subject.version.to_hash).to match hash_including(


### PR DESCRIPTION
Fixes #32 to create resources in the `config.context.namespace` if the resource YAML for a namespaced resource is missing the `metadata.namespace`

* `K8s::Client.config` now sets the `K8s::Client@namespace`
* The `K8s::Client@namespace` is now used for all returned `K8s::ResourceClient` instances
* The `K8s::APIClient` does not have any `@namespace`, and I don't think it makes sense to have one there
* `K8s::APIClient#client_for_resource` ignores the namespace for non-namespaced resources
  * Required for `K8s::Client#create_namespace` with a non-namespaced resource to not fail
* The `K8s::ResourceClient` still raises `RuntimeError` if given a namespace for a non-namespaced resource type
  * It has always done this, but there was never any default namespace that was getting passed in, unless explicitly set in the resource YAML
* The `K8s::ResourceClient` now always has a `@namespace` set for namespaced resources (defaults to 'default'), and the `@namespace` is only nil for non-namespaced resources
  * This changes the behavior of `client.api('v1').resources('service').list` to no longer return all resources, but only the resources in the default namespace instead
  * Listing all resources requires an explicit `client.api('v1').resources('service').list(namespace: nil)`