### PR TITLE
Add propagationPolicy for stack resource delete

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -165,6 +165,8 @@ module K8s
     end
 
     # @param resource [K8s::Resource]
+    # @param options [Hash]
+    # @see ResourceClient#delete for options
     # @return [K8s::Resource]
     def delete_resource(resource, **options)
       client_for_resource(resource).delete_resource(resource, **options)

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -166,8 +166,8 @@ module K8s
 
     # @param resource [K8s::Resource]
     # @return [K8s::Resource]
-    def delete_resource(resource)
-      client_for_resource(resource).delete_resource(resource)
+    def delete_resource(resource, **options)
+      client_for_resource(resource).delete_resource(resource, **options)
     end
   end
 end

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -252,14 +252,14 @@ module K8s
 
     # @param name [String]
     # @param namespace [String]
+    # @param propagationPolicy [String] The propagationPolicy to use for the API call. Possible values include “Orphan”, “Foreground”, or “Background”
     # @return [K8s::API::MetaV1::Status]
-    def delete(name, namespace: @namespace, propagationPolicy: nil, orphanDependents: nil)
+    def delete(name, namespace: @namespace, propagationPolicy: nil)
       @transport.request(
         method: 'DELETE',
         path: self.path(name, namespace: namespace),
         query: make_query(
-          'propagationPolicy' => propagationPolicy,
-          'orphanDependents' => orphanDependents
+          'propagationPolicy' => propagationPolicy
         ),
         response_class: @resource_class, # XXX: documented as returning Status
       )
@@ -284,6 +284,8 @@ module K8s
     end
 
     # @param resource [resource_class] with metadata
+    # @param options [Hash]
+    # @see #delete for possible options
     # @return [K8s::API::MetaV1::Status]
     def delete_resource(resource, **options)
       delete(resource.metadata.name, namespace: resource.metadata.namespace, **options)

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -253,12 +253,13 @@ module K8s
     # @param name [String]
     # @param namespace [String]
     # @return [K8s::API::MetaV1::Status]
-    def delete(name, namespace: @namespace, propagationPolicy: nil)
+    def delete(name, namespace: @namespace, propagationPolicy: nil, orphanDependents: nil)
       @transport.request(
         method: 'DELETE',
         path: self.path(name, namespace: namespace),
         query: make_query(
           'propagationPolicy' => propagationPolicy,
+          'orphanDependents' => orphanDependents
         ),
         response_class: @resource_class, # XXX: documented as returning Status
       )

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -133,7 +133,7 @@ module K8s
         else
           logger.info "Delete resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace}"
           begin
-            client.delete_resource(resource)
+            client.delete_resource(resource, propagationPolicy: 'Foreground')
           rescue K8s::Error::NotFound
             # assume aliased objects in multiple API groups, like for Deployments
             # alternatively, a custom resource whose definition was already deleted earlier

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -133,7 +133,7 @@ module K8s
         else
           logger.info "Delete resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace}"
           begin
-            client.delete_resource(resource, propagationPolicy: 'Foreground')
+            client.delete_resource(resource, propagationPolicy: 'Background')
           rescue K8s::Error::NotFound
             # assume aliased objects in multiple API groups, like for Deployments
             # alternatively, a custom resource whose definition was already deleted earlier


### PR DESCRIPTION
Without `propagationPolicy` some resources are easily left orphaned. For example deleting a deployment leaves behind it's replicasets and thus also pods.

This is because the default policy in many cases is `Orphan` that just removes the owner references.
https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#controlling-how-the-garbage-collector-deletes-dependents

Using `propagationPolicy: 'Foreground'` should make it smoothly delete all dependent resources as part of stack deletion.