### PR TITLE
Fix kubectl set empty namespace in Resource#current_config

### DIFF
--- a/lib/k8s/resource.rb
+++ b/lib/k8s/resource.rb
@@ -82,6 +82,7 @@ module K8s
       return {} unless current_cfg
 
       current_hash = JSON.parse(current_cfg)
+      # kubectl adds empty metadata.namespace, let's fix it
       current_hash['metadata'].delete('namespace') if current_hash.dig('metadata', 'namespace').to_s.empty?
 
       current_hash

--- a/lib/k8s/resource.rb
+++ b/lib/k8s/resource.rb
@@ -27,7 +27,7 @@ module K8s
 
       if stat.directory?
         # recurse
-        Dir.glob("#{path}/*.{yml,yaml}").sort.map{|path| self.from_files(path) }.flatten
+        Dir.glob("#{path}/*.{yml,yaml}").sort.map { |dir| self.from_files(dir) }.flatten
       else
         ::YAML.load_stream(File.read(path), path).map{|doc| new(doc) }
       end
@@ -79,10 +79,12 @@ module K8s
     # @return [Hash]
     def current_config(config_annotation)
       current_cfg = self.metadata.annotations&.dig(config_annotation)
+      return {} unless current_cfg
 
-      return JSON.parse(current_cfg) if current_cfg
+      current_hash = JSON.parse(current_cfg)
+      current_hash['metadata'].delete('namespace') if current_hash.dig('metadata', 'namespace').to_s.empty?
 
-      {}
+      current_hash
     end
 
     def can_patch?(config_annotation)

--- a/spec/k8s/resource_spec.rb
+++ b/spec/k8s/resource_spec.rb
@@ -137,4 +137,29 @@ RSpec.describe K8s::Resource do
       expect(before).not_to eq(after)
     end
   end
+
+  describe "#current_config" do
+    subject { described_class.from_file(fixture_path('resources/service.yaml')) }
+
+    it 'returns empty hash by default' do
+      expect(subject.current_config('foo')).to eq({})
+    end
+
+    it 'returns config object' do
+      config = JSON.parse(JSON.dump(subject.to_hash))
+      subject.metadata['annotations'] = {
+        'foo' => JSON.dump(config)
+      }
+      expect(subject.current_config('foo')).to eq(config)
+    end
+
+    it 'removes kubectl set empty metadata.namespace' do
+      config = JSON.parse(JSON.dump(subject.to_hash))
+      config['metadata']['namespace'] = ''
+      subject.metadata['annotations'] = {
+        'foo' => JSON.dump(config)
+      }
+      expect(subject.current_config('foo')['metadata'].has_key?('namespace')).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Kubectl seems to set an empty namespace to the last-applied-configuration if resource is not namespaced. IMO this is a bug in kubectl but we need to handle this gracefully.