### PR TITLE
Sort objects on prune so namespaced objects are deleted first

### DIFF
--- a/spec/fixtures/resources/namespace.yml
+++ b/spec/fixtures/resources/namespace.yml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test-namespace


### PR DESCRIPTION
Deleting non-namespaced objects first, e.g. a namespace where all other resources live in, can make Stack pruning really fragile.