### PR TITLE
Allow to access client.transport directly

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -45,6 +45,8 @@ module K8s
       new(Transport.in_cluster_config)
     end
 
+    attr_reader :transport
+
     # @param transport [K8s::Transport]
     # @param namespace [String] default namespace for all operations
     def initialize(transport, namespace: nil)

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -190,6 +190,8 @@ module K8s
       end
 
       if response.status.between? 200, 299
+        return response_data if content_type == 'text/plain'
+
         unless response_data.is_a? Hash
           raise K8s::Error::API.new(method, path, response.status, "Invalid JSON response: #{response_data.inspect}")
         end


### PR DESCRIPTION
Makes possible to query kubernetes api's that are not directly supported by k8s-client. For example:

```ruby
      client.transport.get(
        ['api', 'v1', 'namespaces', 'default', 'pods', 'hello-world', 'log'],
        query: {
          follow: '1'
        },
        response_block: lambda do |chunk, _, _|
          p chunk
        end
      )
```

Fixes #46 