### PR TITLE
Fix watch json stream parsing

### DIFF
--- a/k8s-client.gemspec
+++ b/k8s-client.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.0"
   spec.add_runtime_dependency 'hashdiff', '~> 0.3.7'
   spec.add_runtime_dependency 'jsonpath', '~> 0.9.5'
+  spec.add_runtime_dependency 'yajl-ruby', '~> 1.4.0'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -2,6 +2,7 @@
 
 require 'openssl'
 require 'base64'
+require 'yajl'
 
 require 'k8s/api/metav1'
 require 'k8s/api/version'

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -181,7 +181,7 @@ module K8s
 
       case content_type
       when 'application/json'
-        response_data = JSON.parse(response.body)
+        response_data = Yajl::Parser.parse(response.body)
 
       when 'text/plain'
         response_data = response.body # XXX: broken if status 2xx


### PR DESCRIPTION
Watch responses are chunked and can return partial json objects. Previously watch didn't hadle these at all (`JSON::ParserError` was raised). This PR fixes these errors by switching to Yajl stream parser. Normal json responses are now also parsed via Yajl because it should be a bit faster.