### PR TITLE
Release v0.6.3

### DIFF
--- a/lib/k8s/client/version.rb
+++ b/lib/k8s/client/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Client
     # Updated on releases using semver.
-    VERSION = "0.6.2"
+    VERSION = "0.6.3"
   end
 end


### PR DESCRIPTION
- Use k8s ?timeoutSeconds param instead of excon timeout on resource watch (#63)
- Don't parse_response if response_block is given (#62)
- Fix watch json stream parsing (#64)