### PR TITLE
optionally put delete opts into body

### DIFF
--- a/bin/k8s-client
+++ b/bin/k8s-client
@@ -36,7 +36,8 @@ Options = Struct.new(
   :api,
   :list_api_resources,
   :patch_deployment,
-  :replicas
+  :replicas,
+  :version
 )
 
 options = Options.new
@@ -62,6 +63,9 @@ opt_parser = OptionParser.new do |parser|
   parser.on('--quiet') do
     K8s::Logging.quiet!
     K8s::Transport.quiet!
+  end
+  parser.on('--version') do
+    options.version = true
   end
   parser.on('--in-cluster-config') do
     options.in_cluster_config = true
@@ -174,7 +178,11 @@ else
                       ssl_verify_peer: !options.insecure_skip_tls_verify)
 end
 
-logger.info "Kube server version: #{client.version.gitVersion}"
+if options.version
+  logger.info client.version
+else
+  logger.info "Kube server version: #{client.version.gitVersion}"
+end
 
 if options.prefetch_resources
   client.apis(prefetch_resources: true)

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -60,10 +60,7 @@ module K8s
     # @raise [K8s::Error]
     # @return [K8s::API::Version]
     def version
-      @transport.get(
-        '/version',
-        response_class: K8s::API::Version
-      )
+      @api_version ||= @transport.version
     end
 
     # @param api_version [String] "group/version" or "version" (core)

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -60,7 +60,7 @@ module K8s
     # @raise [K8s::Error]
     # @return [K8s::API::Version]
     def version
-      @api_version ||= @transport.version
+      @version ||= @transport.version
     end
 
     # @param api_version [String] "group/version" or "version" (core)

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -311,7 +311,6 @@ module K8s
         ),
         response_class: @resource_class, # XXX: documented as returning Status
       )
-
     end
 
     # @param namespace [String]

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -303,14 +303,21 @@ module K8s
     # @param propagationPolicy [String] The propagationPolicy to use for the API call. Possible values include “Orphan”, “Foreground”, or “Background”
     # @return [K8s::API::MetaV1::Status]
     def delete(name, namespace: @namespace, propagationPolicy: nil)
-      @transport.request(
+      opts = {
         method: 'DELETE',
         path: path(name, namespace: namespace),
-        query: make_query(
-          'propagationPolicy' => propagationPolicy
-        ),
         response_class: @resource_class, # XXX: documented as returning Status
-      )
+      }
+      if ENV['KUBE_DELETE_OPTS_BODY'] && propagationPolicy
+        opts[:request_object] = {
+          propagationPolicy: propagationPolicy
+        }
+      else
+        opts[:query] = make_query(
+          'propagationPolicy' => propagationPolicy
+        )
+      end
+      @transport.request(**opts)
     end
 
     # @param namespace [String]

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -303,21 +303,15 @@ module K8s
     # @param propagationPolicy [String] The propagationPolicy to use for the API call. Possible values include “Orphan”, “Foreground”, or “Background”
     # @return [K8s::API::MetaV1::Status]
     def delete(name, namespace: @namespace, propagationPolicy: nil)
-      opts = {
+      @transport.request(
         method: 'DELETE',
         path: path(name, namespace: namespace),
-        response_class: @resource_class, # XXX: documented as returning Status
-      }
-      if ENV['KUBE_DELETE_OPTS_BODY'] && propagationPolicy
-        opts[:request_object] = {
-          propagationPolicy: propagationPolicy
-        }
-      else
-        opts[:query] = make_query(
+        query: make_query(
           'propagationPolicy' => propagationPolicy
-        )
-      end
-      @transport.request(**opts)
+        ),
+        response_class: @resource_class, # XXX: documented as returning Status
+      )
+
     end
 
     # @param namespace [String]

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -22,6 +22,9 @@ module K8s
       'Accept' => 'application/json'
     }.freeze
 
+    # Min version of Kube API for which delete options need to be sent as request body
+    DELETE_OPTS_BODY_VERSION_MIN = Gem::Version.new('1.11')
+
     # Construct transport from kubeconfig
     #
     # @param config [K8s::Config]
@@ -286,6 +289,7 @@ module K8s
       objects
     end
 
+    # @return [K8s::API::Version]
     def version
       @version ||= get(
         '/version',
@@ -293,8 +297,7 @@ module K8s
       )
     end
 
-    DELETE_OPTS_BODY_VERSION_MIN = Gem::Version.new('1.11')
-
+    # @return [true, false] true if delete options should be sent as bode of the DELETE request
     def need_delete_body?
       @need_delete_body ||= Gem::Version.new(version.gitVersion.match(/v*(.*)/)[1]) < DELETE_OPTS_BODY_VERSION_MIN
     end

--- a/spec/k8s/resource_client_spec.rb
+++ b/spec/k8s/resource_client_spec.rb
@@ -310,6 +310,7 @@ RSpec.describe K8s::ResourceClient do
 
     context "DELETE /api/v1/pods/*" do
       before do
+        allow(transport).to receive(:need_delete_body?).and_return(false)
         stub_request(:delete, 'localhost:8080/api/v1/namespaces/default/pods/test')
           .to_return(
             status: 200,


### PR DESCRIPTION
The problem is that kube 1.9.x and 1.10.7 (at least in GKE setups) fail to take in the delete options in query params. So there needs to be a way to make delete options pushed in body on `DELETE` request.

See: https://github.com/kubernetes/kubernetes/issues/43329#issuecomment-363678598

Needed to fix kontena/mortar#71