### PR TITLE
Replace deep_merge gem with own implementation

### DIFF
--- a/k8s-client.gemspec
+++ b/k8s-client.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "excon", "~> 0.62.0"
   spec.add_runtime_dependency "dry-struct", "~> 0.5.0"
-  spec.add_runtime_dependency "deep_merge", "~> 1.2.1"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.0"
   spec.add_runtime_dependency 'hashdiff', '~> 0.3.7'
   spec.add_runtime_dependency 'jsonpath', '~> 0.9.5'

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -4,19 +4,18 @@ require 'openssl'
 require 'base64'
 require 'yajl'
 
+require 'k8s/util'
+
 require 'k8s/api/metav1'
 require 'k8s/api/version'
-
 require 'k8s/config'
 require 'k8s/logging'
-
 require 'k8s/api_client'
 require "k8s/error"
 require 'k8s/resource'
 require 'k8s/resource_client'
 require 'k8s/stack'
 require 'k8s/transport'
-require 'k8s/util'
 
 module K8s
   # @param server [String] http/s URL

--- a/lib/k8s/resource.rb
+++ b/lib/k8s/resource.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'deep_merge'
 require 'recursive-open-struct'
 require 'hashdiff'
 require 'forwardable'
@@ -13,6 +12,7 @@ module K8s
     include Comparable
 
     using YAMLSafeLoadStream
+    using K8s::Util::HashDeepMerge
 
     # @param data [String]
     # @return [self]

--- a/lib/k8s/util.rb
+++ b/lib/k8s/util.rb
@@ -15,13 +15,15 @@ module K8s
           merge(other) do |key, old_value, new_value|
             case old_value
             when Hash
-              raise "#{key} : #{new_value.class.name} can not be merged into a Hash" unless new_value.kind_of?(Hash)
+              raise "#{key} : #{new_value.class.name} can not be merged into a Hash" unless new_value.is_a?(Hash)
+
               old_value.deep_merge(new_value)
             when Array
               if overwrite_arrays
                 new_value
               else
-                raise "#{key} : #{new_value.class.name} can not be merged into an Array" unless new_value.kind_of?(Array)
+                raise "#{key} : #{new_value.class.name} can not be merged into an Array" unless new_value.is_a?(Array)
+
                 if union_arrays
                   old_value | new_value
                 else
@@ -33,12 +35,10 @@ module K8s
                 old_value.merge(new_value)
               elsif keep_existing
                 old_value
+              elsif new_value.nil? && merge_nil_values
+                nil
               else
-                if new_value.nil? && merge_nil_values
-                  nil
-                else
-                  new_value
-                end
+                new_value
               end
             end
           end


### PR DESCRIPTION
Fixes #80 

The [deep_merge gem](https://github.com/danielsdeleo/deep_merge) seems a bit out of date and it monkey-patches the core Hash class and breaks active support's deep_merge while at it.

We're not using any of the more exotic features of `deep_merge`.
