### PR TITLE
Prefix in_cluster_config paths with $TELEPRESENCE_ROOT

### DIFF
--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -106,8 +106,8 @@ module K8s
       new(
         "https://#{host}:#{port}",
         ssl_verify_peer: options.key?(:ssl_verify_peer) ? options.delete(:ssl_verify_peer) : true,
-        ssl_ca_file: options.delete(:ssl_ca_file) || '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
-        auth_token: options.delete(:auth_token) || File.read('/var/run/secrets/kubernetes.io/serviceaccount/token'),
+        ssl_ca_file: options.delete(:ssl_ca_file) || File.join((ENV['TELEPRESENCE_ROOT'] || '/'), 'var/run/secrets/kubernetes.io/serviceaccount/ca.crt'),
+        auth_token: options.delete(:auth_token) || File.read(File.join((ENV['TELEPRESENCE_ROOT'] || '/'), 'var/run/secrets/kubernetes.io/serviceaccount/token')),
         **options
       )
     end

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe K8s::Transport do
       }
 
       before do
+        allow(ENV).to receive(:[]).with('TELEPRESENCE_ROOT').and_return(nil)
         allow(ENV).to receive(:[]).with('KUBERNETES_SERVICE_HOST').and_return(service_host)
         allow(ENV).to receive(:[]).with('KUBERNETES_SERVICE_PORT_HTTPS').and_return(service_port)
         allow(File).to receive(:read).with('/var/run/secrets/kubernetes.io/serviceaccount/token').and_return(sa_token)
@@ -218,6 +219,18 @@ RSpec.describe K8s::Transport do
         expect(subject.request_options[:headers]).to match hash_including(
           'Authorization' => "Bearer #{sa_token}",
         )
+      end
+
+      context 'with telepresence' do
+        before do
+          allow(ENV).to receive(:[]).with('TELEPRESENCE_ROOT').and_return('/tmp')
+          allow(File).to receive(:read).with('/tmp/var/run/secrets/kubernetes.io/serviceaccount/token').and_return(sa_token)
+          allow(File).to receive(:read).with('/tmp/var/run/secrets/kubernetes.io/serviceaccount/ca.crt').and_return(sa_cacert)
+        end
+
+        it 'uses the correct server' do
+          subject.server
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #86

Prefixes the config paths with `$TELEPRESENCE_ROOT` when set.
