### PR TITLE
Pass options from K8s::Client.in_cluster_config to Transport

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -45,7 +45,7 @@ module K8s
     # @see K8s::Transport#in_cluster_config
     #
     # @param namespace [String] default namespace for all operations
-    # @param options [Hash] options passed, @see Transport#in_cluster_config
+    # @param options [Hash] options passed to transport, @see Transport#in_cluster_config
     # @return [K8s::Client]
     # @raise [K8s::Error::Config,Errno::ENOENT,Errno::EACCES]
     def self.in_cluster_config(namespace: nil, **options)

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -48,7 +48,7 @@ module K8s
     # @return [K8s::Client]
     # @raise [K8s::Error::Config,Errno::ENOENT,Errno::EACCES]
     def self.in_cluster_config(namespace: nil, **options)
-      new(Transport.in_cluster_config, namespace: namespace, **options)
+      new(Transport.in_cluster_config(**options), namespace: namespace)
     end
 
     # Attempts to create a K8s::Client instance automatically using environment variables, existing configuration

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -47,8 +47,8 @@ module K8s
     # @param namespace [String] default namespace for all operations
     # @return [K8s::Client]
     # @raise [K8s::Error::Config,Errno::ENOENT,Errno::EACCES]
-    def self.in_cluster_config(namespace: nil)
-      new(Transport.in_cluster_config, namespace: namespace)
+    def self.in_cluster_config(namespace: nil, **options)
+      new(Transport.in_cluster_config, namespace: namespace, **options)
     end
 
     # Attempts to create a K8s::Client instance automatically using environment variables, existing configuration

--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -45,6 +45,7 @@ module K8s
     # @see K8s::Transport#in_cluster_config
     #
     # @param namespace [String] default namespace for all operations
+    # @param options [Hash] options passed, @see Transport#in_cluster_config
     # @return [K8s::Client]
     # @raise [K8s::Error::Config,Errno::ENOENT,Errno::EACCES]
     def self.in_cluster_config(namespace: nil, **options)


### PR DESCRIPTION
Enables `K8s::Client.in_cluster_config(ssl_ca_file: '/tmp/xxx', auth_token: "abcd")` or adding other transport options.
