### PR TITLE
Fix K8s::Client.autoconfig when using KUBECONFIG

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -70,7 +70,7 @@ module K8s
       if ENV.values_at('KUBE_TOKEN', 'KUBE_CA', 'KUBE_SERVER').none? { |v| v.nil? || v.empty? }
         configuration = K8s::Config.build(server: ENV['KUBE_SERVER'], ca: ENV['KUBE_CA'], auth_token: options[:auth_token] || ENV['KUBE_TOKEN'])
       elsif !ENV['KUBECONFIG'].to_s.empty?
-        configuration = K8s::Config.from_kubeconfig_env(ENV['KUBECONFIG'], auth_token: options[:auth_token])
+        configuration = K8s::Config.from_kubeconfig_env(ENV['KUBECONFIG'])
       elsif File.exist?(File.join(Dir.home, '.kube', 'config'))
         configuration = K8s::Config.load_file(File.join(Dir.home, '.kube', 'config'))
       end

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -110,7 +110,7 @@ module K8s
     # merged using the configuration merge rules, @see K8s::Config.merge
     #
     # @param kubeconfig [String] by default read from ENV['KUBECONFIG']
-    def self.from_kubeconfig_env(kubeconfig = nil, **options)
+    def self.from_kubeconfig_env(kubeconfig = nil)
       kubeconfig ||= ENV.fetch('KUBECONFIG', '')
       return if kubeconfig.empty?
 

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -110,7 +110,7 @@ module K8s
     # merged using the configuration merge rules, @see K8s::Config.merge
     #
     # @param kubeconfig [String] by default read from ENV['KUBECONFIG']
-    def self.from_kubeconfig_env(kubeconfig = nil)
+    def self.from_kubeconfig_env(kubeconfig = nil, **options)
       kubeconfig ||= ENV.fetch('KUBECONFIG', '')
       return if kubeconfig.empty?
 

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -315,7 +315,7 @@ module K8s
         query: make_query(
           'propagationPolicy' => propagationPolicy
         ),
-        response_class: @resource_class, # XXX: documented as returning Status
+        response_class: @resource_class # XXX: documented as returning Status
       )
     end
 
@@ -333,7 +333,7 @@ module K8s
           'fieldSelector' => selector_query(fieldSelector),
           'propagationPolicy' => propagationPolicy
         ),
-        response_class: K8s::API::MetaV1::List, # XXX: documented as returning Status
+        response_class: K8s::API::MetaV1::List # XXX: documented as returning Status
       )
       process_list(list)
     end

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -20,7 +20,7 @@ module K8s
     # These would lead to stack prune misbehaving if not skipped.
     PRUNE_IGNORE = [
       'v1:ComponentStatus', # apiserver ignores GET /v1/componentstatuses?labelSelector=... and returns all resources
-      'v1:Endpoints', # inherits stack label from service, but not checksum annotation
+      'v1:Endpoints' # inherits stack label from service, but not checksum annotation
     ].freeze
 
     # @param name [String] unique name for stack


### PR DESCRIPTION
Fixes #98 

Don't pass the auth_token param to `KUBECONFIG` env loader, it's passed to `Transport.new` after the config is loaded.

