### PR TITLE
Allow timestamps in kubeconfig YAML

### DIFF
--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -103,7 +103,7 @@ module K8s
     # @param path [String]
     # @return [K8s::Config]
     def self.load_file(path)
-      new(YAML.safe_load(File.read(path)))
+      new(YAML.safe_load(File.read(path), [Time,DateTime,Date]))
     end
 
     # Loads configuration files listed in KUBE_CONFIG environment variable and

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -103,7 +103,7 @@ module K8s
     # @param path [String]
     # @return [K8s::Config]
     def self.load_file(path)
-      new(YAML.safe_load(File.read(path), [Time,DateTime,Date]))
+      new(YAML.safe_load(File.read(path), [Time, DateTime, Date]))
     end
 
     # Loads configuration files listed in KUBE_CONFIG environment variable and

--- a/spec/fixtures/config/with_timestamps.conf
+++ b/spec/fixtures/config/with_timestamps.conf
@@ -1,0 +1,27 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNE1EY3dOVEEyTWpjeE5Gb1hEVEk0TURjd01qQTJNamN4TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBS0V4CjR0ZXN2V1hUV1Z4dlVQdzFwS29NNmE3NFhPRlRTdGF4d0YrcDFMVENUN3JmdlE3Nncwems4c3F1ZEh0MUlMRkgKMnpia1d2b3UrcFlhNUE1YUkxUjlMZk1vSGRPQ2ZUeXBqZmdDVVRzdDl1amxuZ0dmK3M0VFRqRndZMzBvSVNRWQpHaHUvajZBL3gzbWhhQ0psODM2SkhGeTZDTnE1OTk5MU5uMDlDT0RXc0NPbUZ6RHY3K2VaSGZiVzNIMjU1YUpFCm5zS2RHRTJ2ejNSdnVpbmRUUk1FZnhpc1RkRmx1YTZCMWp3MDF2MWRhWlcvek5sSXF6NDRieFJOTmlONFhLVngKeTJqb0dYSDI1aW5udmc4dDQwL1JCSStvamppcU1nQUlRUHVkdVJacW1pYnJMcytDdmtGcUVVWml3cWdWS0ZGQgpwVHQ0dHB5NjVIckZGZVdwcGFjQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFKbGE3ejFWb0dPMmNiL00vK0RJcW1vQit4T2UKY0FJTUJxYTNXZUZQUXZ1N2dFbGh3cTBFRndTQmRtOUp6R0xqVHRxbGZ5ai8veEgwc08wdWt3WS9NTkRhODdsZQpXT1lsZFN3RW5WQXhmVjRvU0U1N2J4ci9NeE1YVnlYRXVDc1VOTFhXbG9SM251Y3hINHQzUFRSV0ZrejRyZ1ZSCk95WUtsL2w4VW9ZQWQ5VytsRHBaa1ZXa2oxbDZXQTJZck5YQVdtZTNnb2xMS3FLSUpZTUhKUlhVbnBHSWN2SHUKWVZDaGxqbjVQMnpubkVrRms5aTVtZjZ0ZDlXNEErc0cwTUJkV3c2bUl0RWRSZmM0MVNQWUgrcUQwZDZaZDNzUwo2ZzRhaXA4Z2dmRG9SbjBDL0FKb3lFVkxRL0ZPdy9ua0NJNnRDSDQ2amZXak0rb2plbFVDSHRMcHFjRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    server: https://192.168.56.11:6443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubernetes-admin
+  name: kubernetes-admin@kubernetes
+current-context: kubernetes-admin@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+    auth-provider:
+      config:
+        access-token:
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/gcloud
+        expiry: 2019-01-29T14:20:36Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+

--- a/spec/k8s/config_spec.rb
+++ b/spec/k8s/config_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe K8s::Config do
         )
       end
     end
+
+    context 'for a config with timestamps' do
+      subject {
+        described_class.load_file(fixture_path('config/with_timestamps.conf'))
+      }
+
+      it "does not raise" do
+        expect{described_class.load_file(fixture_path('config/with_timestamps.conf'))}.not_to raise_error
+      end
+    end
   end
 
   describe '#self.from_kubeconfig_env' do


### PR DESCRIPTION
Fixes #102
Ref: https://github.com/kontena/mortar/issues/93 (will fix when k8s-client upgraded to a version including this PR)

Allows `Time`, `DateTime`, and `Date` in YAMLs when loading kubeconfigs, which previously would have caused a `Psych::DisallowedClass` exception.
