### PR TITLE
Fix multiple problems in K8s::Client.autoconfig

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -68,7 +68,17 @@ module K8s
     # @return [K8s::Client]
     def self.autoconfig(namespace: nil, **options)
       if ENV.values_at('KUBE_TOKEN', 'KUBE_CA', 'KUBE_SERVER').none? { |v| v.nil? || v.empty? }
-        configuration = K8s::Config.build(server: ENV['KUBE_SERVER'], ca: ENV['KUBE_CA'], auth_token: options[:auth_token] || ENV['KUBE_TOKEN'])
+        unless Base64.decode64(ENV['KUBE_CA']).match?(/CERTIFICATE/)
+          raise ArgumentError, 'KUBE_CA does not seem to be base64 encoded'
+        end
+
+        begin
+          token = options[:auth_token] || Base64.strict_decode64(ENV['KUBE_TOKEN'])
+        rescue ArgumentError
+          raise ArgumentError, 'KUBE_TOKEN does not seem to be base64 encoded'
+        end
+
+        configuration = K8s::Config.build(server: ENV['KUBE_SERVER'], ca: ENV['KUBE_CA'], auth_token: token)
       elsif !ENV['KUBECONFIG'].to_s.empty?
         configuration = K8s::Config.from_kubeconfig_env(ENV['KUBECONFIG'])
       elsif File.exist?(File.join(Dir.home, '.kube', 'config'))

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -182,6 +182,7 @@ module K8s
     def context(name = current_context)
       found = contexts.find{ |context| context.name == name }
       raise K8s::Error::Configuration, "context not found: #{name.inspect}" unless found
+
       found.context
     end
 

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -116,10 +116,9 @@ module K8s
 
       paths = kubeconfig.split(/(?!\\):/)
 
-      res = paths.inject(load_file(paths.shift)) do |memo, other_cfg|
+      paths.inject(load_file(paths.shift)) do |memo, other_cfg|
         memo.merge(load_file(other_cfg))
       end
-      res
     end
 
     # Build a minimal configuration from at least a server address, server certificate authority data and an access token.

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -1,6 +1,149 @@
 RSpec.describe K8s::Client do
   include FixtureHelpers
 
+  describe '#autoconfig' do
+    let(:ca_b64) { "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNE1USXhPVEE1TXpJek5Wb1hEVEk0TVRJeE5qQTVNekl6TlZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTUpsCnBHOVZSamFKMEtWTDM5UXdTemNPRmluZjNGb0MwRkh2bG1HUTVIQ202Q2RZT0VyYXFhTlhIaHZ6UjAyT1lreWoKTmFZK2N0NFl6MEc3TlBmQWlWRFNhRW9zdEZZLzVzdXMwOGJKc0g3Z1E4TkZMMk5qcCtlSWtVTktuNkltcldENQpxaFZVVkV6Q2tCSEsvRjJ1N3hoaTV1M1lvUGJOMjJtZHptZ011TjRGMVF4QnlDOU1ML01kWm4wdDdObTNSeVRaCkJndExqQ05Ea0VaRUFRbm81VmtJMVlNQUdwRmZZcUhXbURRczRabjRzdTJlay95bjhhZkk3RG9yN242MEg3aWkKNC84Y0JWT1RZOTRieElWaW1ETHdjNjkvTXJZN09vTmw0RUpwTEVYdTVzMzFxbE80UkFUYjI4VkNOelBUWWd5ZwpUeWt4T2dIeTl4ZXRnOUkrVzU4Q0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFCUFBiQzhDRzZiaXZ5OGJzcmtiUENtRjBTREMKdjRJbm5QZkZWTXRnZzB2aFh3d1BhaHNyVUNHRmw1d2wwVitTQS96TDkzTmhuTEFuTnFPWFNtaHJZTWZ2NU5GaApwUFlsaTlpMVNWZk1Pc3BkbGxhWEEvV1ZMenZqcEt5S3FtdVNGU3hzRzJuTVpackJ0MitzUDAvUW1MWDVnUS8yCk5sUFZ3a2E5alRoVjBIVUN5a3ptNy9GYU1GbjZUd0xKWWszWWFQN1o1QVQ5c01wYTIyRzBWWEhQVllHVWQ1K1QKWTNBUStjTEo2bjBsQnVJSmsydzFsUzdjK3ZsN2dLczYrVm9LajRFM2lQdDkwQy9lR3ZMaStZcGU5bGI0dm5ZYgpmMXNWL0h0RjkwMDF0USthQ044RnpGelhQNGV1aHlZYW0ycGt6M3V5bmVHT21wKzI1UHRMMGc2RGRQOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=" }
+
+    let(:kubeconfig) do
+      <<~EOB
+        ---
+        apiVersion: v1
+        clusters:
+        - cluster:
+            certificate-authority-data: #{ca_b64}
+            server: https://192.168.100.100:6443
+          name: kubernetes
+        contexts:
+        - context:
+            cluster: kubernetes
+            user: kubernetes-admin
+          name: kubernetes-admin@kubernetes
+        current-context: kubernetes-admin@kubernetes
+        kind: Config
+        preferences: {}
+        users:
+        - name: kubernetes-admin
+          user:
+            client-certificate-data: #{ca_b64}
+            client-key-data: #{ca_b64}
+      EOB
+    end
+
+    let(:default_kubeconfig_path) { File.join(Dir.home, '.kube', 'config') }
+
+
+    subject { described_class }
+    context 'from KUBE_CA/KUBE_SERVER/KUBE_TOKEN variables' do
+
+      let(:server) { "localhost" }
+      let(:env) { { 'KUBE_TOKEN' => token, 'KUBE_CA' => ca, 'KUBE_SERVER' => server } }
+
+      before do
+        stub_const("ENV", env)
+      end
+
+      context 'KUBE_TOKEN is not base64 encoded' do
+        let(:ca) { ca_b64 }
+        let(:token) { 'foobar' }
+
+        it 'raises' do
+          expect{subject.autoconfig}.to raise_error(ArgumentError, /KUBE_TOKEN.*base64/)
+        end
+      end
+
+      context 'KUBE_CA is not base64 encoded' do
+        let(:ca) { Base64.decode64(ca_b64) }
+        let(:token) { Base64.encode64('foobar').chomp }
+
+        it 'raises' do
+          expect{subject.autoconfig}.to raise_error(ArgumentError, /KUBE_CA.*base64/)
+        end
+      end
+
+      context 'both KUBE_CA and KUBE_TOKEN are base64 encoded' do
+        let(:ca) { ca_b64 }
+        let(:token) { Base64.encode64('foobar').chomp }
+
+        it 'returns a correctly configured client' do
+          client = subject.autoconfig
+          expect(client).to be_a K8s::Client
+          expect(client.transport.instance_variable_get(:@auth_token)).to eq 'foobar'
+        end
+      end
+    end
+
+    context 'from KUBECONFIG variable' do
+      let(:env) { { 'KUBECONFIG' => kubeconfig_string } }
+
+      before do
+        stub_const("ENV", env)
+      end
+
+      context 'KUBECONFIG contains a single path' do
+        let(:kubeconfig_string) { '~/.kube/config' }
+
+        it 'loads the file and returns a client' do
+          expect(File).to receive(:read).with(File.join(Dir.home, '.kube', 'config')).and_return(kubeconfig)
+          expect(subject.autoconfig).to be_a K8s::Client
+        end
+      end
+
+      context 'KUBECONFIG contains a multiple paths' do
+        let(:kubeconfig_string) { '~/.kube/config:~/.kube/config2' }
+        let(:kubeconfig2) do
+          <<~EOB
+            ---
+            apiVersion: v1
+            clusters:
+            - cluster:
+                certificate-authority-data: #{ca_b64}
+                server: https://192.168.100.100:6443
+              name: kube2
+            contexts:
+            - context:
+                cluster: kube2
+                user: kubernetes-admin
+              name: kubernetes-admin@kube2
+            current-context: kubernetes-admin@kube2
+            kind: Config
+            preferences: {}
+            users:
+            - name: kubernetes-admin
+              user:
+                client-certificate-data: #{ca_b64}
+                client-key-data: #{ca_b64}
+          EOB
+        end
+
+        it 'loads all of the files, merges them and returns a client' do
+          expect(File).to receive(:read).with(File.join(Dir.home, '.kube', 'config')).and_return(kubeconfig)
+          expect(File).to receive(:read).with(File.join(Dir.home, '.kube', 'config2')).and_return(kubeconfig2)
+          expect(subject.autoconfig).to be_a K8s::Client
+        end
+      end
+    end
+
+    context 'from default ~/.kube/config' do
+      it 'loads the file' do
+        expect(File).to receive(:exist?).with(default_kubeconfig_path).and_return(true)
+        expect(File).to receive(:read).with(default_kubeconfig_path).and_return(kubeconfig)
+        expect(subject.autoconfig).to be_a K8s::Client
+      end
+    end
+
+    context 'from in_cluster_config' do
+      before do
+        allow(File).to receive(:exist?).with(default_kubeconfig_path).and_return(false)
+        stub_const("ENV", {})
+      end
+
+      it 'resorts to in_cluster_config finally' do
+        expect(subject).to receive(:in_cluster_config)
+        subject.autoconfig
+      end
+    end
+  end
+
   context "for a mocked API" do
     let(:transport) { K8s::Transport.new('http://localhost:8080') }
 

--- a/spec/k8s/config_spec.rb
+++ b/spec/k8s/config_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe K8s::Config do
   describe '#self.from_kubeconfig_env' do
     context 'KUBECONFIG points to a single file' do
       it 'reads the file' do
-        expect(File).to receive(:read).with('kubeconfig_path').and_return(YAML.dump('current_context' => 'foo'))
+        expect(File).to receive(:read).with(File.expand_path('kubeconfig_path')).and_return(YAML.dump('current_context' => 'foo'))
         described_class.from_kubeconfig_env('kubeconfig_path')
       end
     end
 
     context 'KUBECONFIG points to two files' do
       it 'reads all of the files' do
-        expect(File).to receive(:read).with('kubeconfig_path').and_return(YAML.dump('current_context' => 'foo'))
-        expect(File).to receive(:read).with('kubeconfig2_path').and_return(YAML.dump('current_context' => 'should not overwrite 1'))
+        expect(File).to receive(:read).with(File.expand_path('kubeconfig_path')).and_return(YAML.dump('current_context' => 'foo'))
+        expect(File).to receive(:read).with(File.expand_path('kubeconfig2_path')).and_return(YAML.dump('current_context' => 'should not overwrite 1'))
         expect(described_class.from_kubeconfig_env('kubeconfig_path:kubeconfig2_path').current_context).to eq 'foo'
       end
     end


### PR DESCRIPTION
The `K8s::Client.autoconfig` had several problems:

* The base64 check for `KUBE_TOKEN` was not working 
* The `KUBE_CA` was not checked for base64 at all. The check in this PR is a little so-and-so.
* The multi-path KUBECONFIG merge mechanism had a leftover debug puts
* The KUBECONFIG loader did not expand paths, `~/.kube/config` would not have worked.
* There were no specs
