### PR TITLE
Support existing resources without annotations

### DIFF
--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -101,7 +101,7 @@ module K8s
         if !server_resource
           logger.info "Create resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           keep_resource! client.create_resource(prepare_resource(resource))
-        elsif server_resource.metadata.annotations.nil? || server_resource.metadata.annotations[@checksum_annotation] != resource.checksum
+        elsif server_resource.metadata&.annotations[@checksum_annotation] != resource.checksum
           logger.info "Update resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           r = prepare_resource(resource)
           if server_resource.can_patch?(@last_config_annotation)

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -101,7 +101,7 @@ module K8s
         if !server_resource
           logger.info "Create resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           keep_resource! client.create_resource(prepare_resource(resource))
-        elsif server_resource.metadata.annotations[@checksum_annotation] != resource.checksum
+        elsif server_resource.metadata.annotations.nil? || server_resource.metadata.annotations[@checksum_annotation] != resource.checksum
           logger.info "Update resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           r = prepare_resource(resource)
           if server_resource.can_patch?(@last_config_annotation)


### PR DESCRIPTION
I get a failure in the case where I am applying a stack that has a resource in it that 

- exists in the cluster (maybe created with some other process)
- has no annotations.

Pharos errors in such a case with `ERROR: NoMethodError : undefined method `[]' for nil:NilClass`

This change will allow pharos to begin managing such a resource even though the checksum does not exist at first.