### PR TITLE
Update Dry Struct and update usages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 matrix:
   allow_failures:
   - rvm: ruby-head
-before_install: gem install bundler -v 1.16.2
+before_install: gem install bundler
 deploy:
   provider: rubygems
   gem: k8s-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   allow_failures:
   - rvm: ruby-head
 before_install: gem install bundler
+script: bundle exec rspec spec/
 deploy:
   provider: rubygems
   gem: k8s-client

--- a/bin/k8s-client
+++ b/bin/k8s-client
@@ -313,8 +313,8 @@ options.delete_resources.each do |resource|
     resource = client.delete_resource(resource)
 
     logger.info "Deleted #{resource.apiVersion} resource #{resource.kind} #{resource.metadata.name} in namespace #{resource.metadata.namespace}:\n#{JSON.pretty_generate(resource)}"
-  rescue K8s::Error::NotFound => exc
-    logger.info "Skip #{resource.apiVersion} resource #{resource.kind} #{resource.metadata.name} in namespace #{resource.metadata.namespace}: #{exc}"
+  rescue K8s::Error::NotFound => e
+    logger.info "Skip #{resource.apiVersion} resource #{resource.kind} #{resource.metadata.name} in namespace #{resource.metadata.namespace}: #{e}"
   end
 end
 

--- a/k8s-client.gemspec
+++ b/k8s-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_runtime_dependency "excon", "~> 0.62.0"
-  spec.add_runtime_dependency "dry-struct", "~> 0.5.0"
+  spec.add_runtime_dependency "dry-struct", "~> 0.7.0"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.0"
   spec.add_runtime_dependency 'hashdiff', '~> 0.3.7'
   spec.add_runtime_dependency 'jsonpath', '~> 0.9.5'

--- a/k8s-client.gemspec
+++ b/k8s-client.gemspec
@@ -31,9 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'yajl-ruby', '~> 1.4.0'
   spec.add_runtime_dependency "yaml-safe_load_stream", "~> 0.1"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.17", "< 3.0"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.4.2"
-  spec.add_development_dependency "rubocop", "~> 0.59"
+  spec.add_development_dependency "rubocop", "~> 0.67"
 end

--- a/lib/k8s/api.rb
+++ b/lib/k8s/api.rb
@@ -8,7 +8,7 @@ module K8s
   module API
     # Common Dry::Types used in the API
     module Types
-      include Dry::Types.module
+      include Dry.Types()
     end
 
     # Common API struct type, handling JSON transforms with symbol keys

--- a/lib/k8s/api.rb
+++ b/lib/k8s/api.rb
@@ -23,7 +23,7 @@ module K8s
       end
 
       # @return [String]
-      def to_json
+      def to_json(*_args)
         to_hash.to_json
       end
     end

--- a/lib/k8s/api/metav1.rb
+++ b/lib/k8s/api/metav1.rb
@@ -11,8 +11,8 @@ module K8s
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#TypeMeta
       class Resource < Struct
         # XXX: making these optional seems dangerous, but some APIs (GET /api/v1) are missing these
-        attribute :kind, Types::Strict::String.optional.default(nil)
-        attribute :apiVersion, Types::Strict::String.optional.default(nil)
+        attribute :kind, Types::String.optional.default(nil)
+        attribute :apiVersion, Types::String.optional.default(nil)
       end
     end
   end

--- a/lib/k8s/api/metav1/api_group.rb
+++ b/lib/k8s/api/metav1/api_group.rb
@@ -6,20 +6,20 @@ module K8s
       # structured list of available APIGroup versions
       # groupVersion provided for convenience
       class APIGroupVersion < Struct
-        attribute :groupVersion, Types::Strict::String
-        attribute :version, Types::Strict::String
+        attribute :groupVersion, Types::String
+        attribute :version, Types::String
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIGroup
       class APIGroup < Struct
-        attribute :name, Types::Strict::String
-        attribute :versions, Types::Strict::Array.of(APIGroupVersion)
+        attribute :name, Types::String
+        attribute :versions, Types::Array.of(APIGroupVersion)
         attribute :preferredVersion, APIGroupVersion
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIGroupList
       class APIGroupList < Resource
-        attribute :groups, Types::Strict::Array.of(APIGroup)
+        attribute :groups, Types::Array.of(APIGroup)
       end
     end
   end

--- a/lib/k8s/api/metav1/api_resource.rb
+++ b/lib/k8s/api/metav1/api_resource.rb
@@ -5,21 +5,21 @@ module K8s
     module MetaV1
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIResource
       class APIResource < Struct
-        attribute :name, Types::Strict::String
-        attribute :singularName, Types::Strict::String
-        attribute :namespaced, Types::Strict::Bool
-        attribute :group, Types::Strict::String.optional.default(nil)
-        attribute :version, Types::Strict::String.optional.default(nil)
-        attribute :kind, Types::Strict::String
-        attribute :verbs, Types::Strict::Array.of(Types::Strict::String)
-        attribute :shortNames, Types::Strict::Array.of(Types::Strict::String).optional.default { [] }
-        attribute :categories, Types::Strict::Array.of(Types::Strict::String).optional.default { [] }
+        attribute :name, Types::String
+        attribute :singularName, Types::String
+        attribute :namespaced, Types::Bool
+        attribute :group, Types::String.optional.default(nil)
+        attribute :version, Types::String.optional.default(nil)
+        attribute :kind, Types::String
+        attribute :verbs, Types::Array.of(Types::Strict::String)
+        attribute :shortNames, Types::Array.of(Types::Strict::String).optional.default { [] }
+        attribute :categories, Types::Array.of(Types::Strict::String).optional.default { [] }
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIResourceList
       class APIResourceList < Resource
-        attribute :groupVersion, Types::Strict::String
-        attribute :resources, Types::Strict::Array.of(APIResource)
+        attribute :groupVersion, Types::String
+        attribute :resources, Types::Array.of(APIResource)
       end
     end
   end

--- a/lib/k8s/api/metav1/api_resource.rb
+++ b/lib/k8s/api/metav1/api_resource.rb
@@ -12,8 +12,8 @@ module K8s
         attribute :version, Types::String.optional.default(nil)
         attribute :kind, Types::String
         attribute :verbs, Types::Array.of(Types::Strict::String)
-        attribute :shortNames, Types::Array.of(Types::Strict::String).optional.default { [] }
-        attribute :categories, Types::Array.of(Types::Strict::String).optional.default { [] }
+        attribute(:shortNames, Types::Array.of(Types::Strict::String).optional.default { [] })
+        attribute(:categories, Types::Array.of(Types::Strict::String).optional.default { [] })
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIResourceList

--- a/lib/k8s/api/metav1/api_resource.rb
+++ b/lib/k8s/api/metav1/api_resource.rb
@@ -12,8 +12,8 @@ module K8s
         attribute :version, Types::Strict::String.optional.default(nil)
         attribute :kind, Types::Strict::String
         attribute :verbs, Types::Strict::Array.of(Types::Strict::String)
-        attribute :shortNames, Types::Strict::Array.of(Types::Strict::String).optional.default([])
-        attribute :categories, Types::Strict::Array.of(Types::Strict::String).optional.default([])
+        attribute :shortNames, Types::Strict::Array.of(Types::Strict::String).optional.default { [] }
+        attribute :categories, Types::Strict::Array.of(Types::Strict::String).optional.default { [] }
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#APIResourceList

--- a/lib/k8s/api/metav1/list.rb
+++ b/lib/k8s/api/metav1/list.rb
@@ -5,15 +5,15 @@ module K8s
     module MetaV1
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta
       class ListMeta < Struct
-        attribute :selfLink, Types::Strict::String.optional.default(nil)
-        attribute :resourceVersion, Types::Strict::String.optional.default(nil)
-        attribute :continue, Types::Strict::String.optional.default(nil)
+        attribute :selfLink, Types::String.optional.default(nil)
+        attribute :resourceVersion, Types::String.optional.default(nil)
+        attribute :continue, Types::String.optional.default(nil)
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#List
       class List < Resource
         attribute :metadata, ListMeta
-        attribute :items, Types::Strict::Array # untyped
+        attribute :items, Types::Array # untyped
       end
     end
   end

--- a/lib/k8s/api/metav1/object.rb
+++ b/lib/k8s/api/metav1/object.rb
@@ -7,15 +7,15 @@ module K8s
     module MetaV1
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#OwnerReference
       class OwnerReference < Resource
-        attribute :name, Types::Strict::String
-        attribute :uid, Types::Strict::String
-        attribute :controller, Types::Strict::Bool.optional.default(nil)
-        attribute :blockOwnerDeletion, Types::Strict::Bool.optional.default(nil)
+        attribute :name, Types::String
+        attribute :uid, Types::String
+        attribute :controller, Types::Bool.optional.default(nil)
+        attribute :blockOwnerDeletion, Types::Bool.optional.default(nil)
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Initializer
       class Initializer < Struct
-        attribute :name, Types::Strict::String
+        attribute :name, Types::String
       end
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Initializers
@@ -26,22 +26,22 @@ module K8s
 
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta
       class ObjectMeta < Resource
-        attribute :name, Types::Strict::String.optional.default(nil)
-        attribute :generateName, Types::Strict::String.optional.default(nil)
-        attribute :namespace, Types::Strict::String.optional.default(nil)
-        attribute :selfLink, Types::Strict::String.optional.default(nil)
-        attribute :uid, Types::Strict::String.optional.default(nil)
-        attribute :resourceVersion, Types::Strict::String.optional.default(nil)
-        attribute :generation, Types::Strict::Integer.optional.default(nil)
+        attribute :name, Types::String.optional.default(nil)
+        attribute :generateName, Types::String.optional.default(nil)
+        attribute :namespace, Types::String.optional.default(nil)
+        attribute :selfLink, Types::String.optional.default(nil)
+        attribute :uid, Types::String.optional.default(nil)
+        attribute :resourceVersion, Types::String.optional.default(nil)
+        attribute :generation, Types::Integer.optional.default(nil)
         attribute :creationTimestamp, Types::DateTime.optional.default(nil)
         attribute :deletionTimestamp, Types::DateTime.optional.default(nil)
-        attribute :deletionGracePeriodSeconds, Types::Strict::Integer.optional.default(nil)
-        attribute :labels, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
-        attribute :annotations, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
-        attribute :ownerReferences, Types::Strict::Array.of(OwnerReference).optional.default { [] }
+        attribute :deletionGracePeriodSeconds, Types::Integer.optional.default(nil)
+        attribute :labels, Types::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
+        attribute :annotations, Types::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
+        attribute :ownerReferences, Types::Array.of(OwnerReference).optional.default { [] }
         attribute :initializers, Initializers.optional.default(nil)
-        attribute :finalizers, Types::Strict::Array.of(Types::Strict::String).optional.default { [] }
-        attribute :clusterName, Types::Strict::String.optional.default(nil)
+        attribute :finalizers, Types::Array.of(Types::Strict::String).optional.default { [] }
+        attribute :clusterName, Types::String.optional.default(nil)
       end
 
       # common attributes shared by all object types

--- a/lib/k8s/api/metav1/object.rb
+++ b/lib/k8s/api/metav1/object.rb
@@ -38,9 +38,9 @@ module K8s
         attribute :deletionGracePeriodSeconds, Types::Strict::Integer.optional.default(nil)
         attribute :labels, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
         attribute :annotations, Types::Strict::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
-        attribute :ownerReferences, Types::Strict::Array.of(OwnerReference).optional.default([])
+        attribute :ownerReferences, Types::Strict::Array.of(OwnerReference).optional.default { [] }
         attribute :initializers, Initializers.optional.default(nil)
-        attribute :finalizers, Types::Strict::Array.of(Types::Strict::String).optional.default([])
+        attribute :finalizers, Types::Strict::Array.of(Types::Strict::String).optional.default { [] }
         attribute :clusterName, Types::Strict::String.optional.default(nil)
       end
 

--- a/lib/k8s/api/metav1/object.rb
+++ b/lib/k8s/api/metav1/object.rb
@@ -38,9 +38,9 @@ module K8s
         attribute :deletionGracePeriodSeconds, Types::Integer.optional.default(nil)
         attribute :labels, Types::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
         attribute :annotations, Types::Hash.map(Types::Strict::String, Types::Strict::String).optional.default(nil)
-        attribute :ownerReferences, Types::Array.of(OwnerReference).optional.default { [] }
+        attribute(:ownerReferences, Types::Array.of(OwnerReference).optional.default { [] })
         attribute :initializers, Initializers.optional.default(nil)
-        attribute :finalizers, Types::Array.of(Types::Strict::String).optional.default { [] }
+        attribute(:finalizers, Types::Array.of(Types::Strict::String).optional.default { [] })
         attribute :clusterName, Types::String.optional.default(nil)
       end
 

--- a/lib/k8s/api/metav1/status.rb
+++ b/lib/k8s/api/metav1/status.rb
@@ -7,27 +7,27 @@ module K8s
       class Status < Resource
         # structured cause
         class Cause < Struct
-          attribute :reason, Types::Strict::String.optional.default(nil)
-          attribute :message, Types::Strict::String.optional.default(nil) # human-readable
-          attribute :field, Types::Strict::String.optional.default(nil) # human-readable
+          attribute :reason, Types::String.optional.default(nil)
+          attribute :message, Types::String.optional.default(nil) # human-readable
+          attribute :field, Types::String.optional.default(nil) # human-readable
         end
 
         # structured details
         class Details < Struct
-          attribute :name, Types::Strict::String.optional.default(nil)
-          attribute :group, Types::Strict::String.optional.default(nil)
-          attribute :kind, Types::Strict::String.optional.default(nil)
-          attribute :uid, Types::Strict::String.optional.default(nil)
-          attribute :causes, Types::Strict::Array.of(Cause).optional.default(nil)
-          attribute :retryAfterSeconds, Types::Strict::Integer.optional.default(nil)
+          attribute :name, Types::String.optional.default(nil)
+          attribute :group, Types::String.optional.default(nil)
+          attribute :kind, Types::String.optional.default(nil)
+          attribute :uid, Types::String.optional.default(nil)
+          attribute :causes, Types::Array.of(Cause).optional.default(nil)
+          attribute :retryAfterSeconds, Types::Integer.optional.default(nil)
         end
 
         attribute :metadata, ListMeta
-        attribute :status, Types::Strict::String.enum('Success', 'Failure').optional.default(nil)
-        attribute :message, Types::Strict::String.optional.default(nil) # human-readable
-        attribute :reason, Types::Strict::String.optional.default(nil) # machine-readable
+        attribute :status, Types::String.enum('Success', 'Failure').optional.default(nil)
+        attribute :message, Types::String.optional.default(nil) # human-readable
+        attribute :reason, Types::String.optional.default(nil) # machine-readable
         attribute :details, Details.optional.default(nil)
-        attribute :code, Types::Strict::Integer.optional.default(nil)
+        attribute :code, Types::Integer.optional.default(nil)
       end
     end
   end

--- a/lib/k8s/api/metav1/watch_event.rb
+++ b/lib/k8s/api/metav1/watch_event.rb
@@ -7,8 +7,8 @@ module K8s
     module MetaV1
       # @see https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#WatchEvent
       class WatchEvent < Resource
-        attribute :type, Types::Strict::String
-        attribute :object, Types::Strict::Hash
+        attribute :type, Types::String
+        attribute :object, Types::Hash
 
         # @return [K8s::Resource]
         def resource

--- a/lib/k8s/api/version.rb
+++ b/lib/k8s/api/version.rb
@@ -4,14 +4,14 @@ module K8s
   module API
     # GET /version
     class Version < Struct
-      attribute :buildDate, Types::Strict::String # TODO: parse datetime?
-      attribute :compiler, Types::Strict::String
-      attribute :gitCommit, Types::Strict::String
-      attribute :gitTreeState, Types::Strict::String
-      attribute :gitVersion, Types::Strict::String
-      attribute :major, Types::Strict::String
-      attribute :minor, Types::Strict::String
-      attribute :platform, Types::Strict::String
+      attribute :buildDate, Types::String # TODO: parse datetime?
+      attribute :compiler, Types::String
+      attribute :gitCommit, Types::String
+      attribute :gitTreeState, Types::String
+      attribute :gitVersion, Types::String
+      attribute :major, Types::String
+      attribute :minor, Types::String
+      attribute :platform, Types::String
     end
   end
 end

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -25,7 +25,7 @@ module K8s
   class Config < ConfigStruct
     # Common dry-types for config
     class Types
-      include Dry::Types.module
+      include Dry.Types()
     end
 
     # structured cluster
@@ -91,12 +91,12 @@ module K8s
 
     attribute :kind, Types::Strict::String.optional.default(nil)
     attribute :apiVersion, Types::Strict::String.optional.default(nil)
-    attribute :preferences, Types::Strict::Hash.optional.default(proc { {} })
-    attribute :clusters, Types::Strict::Array.of(NamedCluster).optional.default(proc { [] })
-    attribute :users, Types::Strict::Array.of(NamedUser).optional.default(proc { [] })
-    attribute :contexts, Types::Strict::Array.of(NamedContext).optional.default(proc { [] })
+    attribute :preferences, Types::Strict::Hash.optional.default { {} }
+    attribute :clusters, Types::Strict::Array.of(NamedCluster).optional.default { [] }
+    attribute :users, Types::Strict::Array.of(NamedUser).optional.default { [] }
+    attribute :contexts, Types::Strict::Array.of(NamedContext).optional.default{ [] }
     attribute :current_context, Types::Strict::String.optional.default(nil)
-    attribute :extensions, Types::Strict::Array.optional.default(proc { [] })
+    attribute :extensions, Types::Strict::Array.optional.default { [] }
 
     # Loads a configuration from a YAML file
     #

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -91,12 +91,12 @@ module K8s
 
     attribute :kind, Types::String.optional.default(nil)
     attribute :apiVersion, Types::String.optional.default(nil)
-    attribute :preferences, Types::Hash.optional.default { {} }
-    attribute :clusters, Types::Array.of(NamedCluster).optional.default { [] }
-    attribute :users, Types::Array.of(NamedUser).optional.default { [] }
-    attribute :contexts, Types::Array.of(NamedContext).optional.default{ [] }
+    attribute(:preferences, Types::Hash.optional.default { {} })
+    attribute(:clusters, Types::Array.of(NamedCluster).optional.default { [] })
+    attribute(:users, Types::Array.of(NamedUser).optional.default { [] })
+    attribute(:contexts, Types::Array.of(NamedContext).optional.default { [] })
     attribute :current_context, Types::String.optional.default(nil)
-    attribute :extensions, Types::Array.optional.default { [] }
+    attribute(:extensions, Types::Array.optional.default { [] })
 
     # Loads a configuration from a YAML file
     #
@@ -174,7 +174,6 @@ module K8s
           when NilClass
             new_value
           else
-            STDERR.puts "key is #{key} old val is #{old_value.inspect} and new val is #{new_value.inspect}"
             old_value
           end
         end

--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -34,7 +34,7 @@ module K8s
       attribute :insecure_skip_tls_verify, Types::Bool.optional.default(nil)
       attribute :certificate_authority, Types::String.optional.default(nil)
       attribute :certificate_authority_data, Types::String.optional.default(nil)
-      attribute :extensions, Types::Strict::Array.optional.default(nil)
+      attribute :extensions, Types::Array.optional.default(nil)
     end
 
     # structured cluster with name
@@ -46,7 +46,7 @@ module K8s
     # structured user auth provider
     class UserAuthProvider < ConfigStruct
       attribute :name, Types::String
-      attribute :config, Types::Strict::Hash
+      attribute :config, Types::Hash
     end
 
     # structured user
@@ -63,8 +63,8 @@ module K8s
       attribute :username, Types::String.optional.default(nil)
       attribute :password, Types::String.optional.default(nil)
       attribute :auth_provider, UserAuthProvider.optional.default(nil)
-      attribute :exec, Types::Strict::Hash.optional.default(nil)
-      attribute :extensions, Types::Strict::Array.optional.default(nil)
+      attribute :exec, Types::Hash.optional.default(nil)
+      attribute :extensions, Types::Array.optional.default(nil)
     end
 
     # structured user with name
@@ -77,10 +77,10 @@ module K8s
     #
     # Referrs to other named User/cluster objects within the same config.
     class Context < ConfigStruct
-      attribute :cluster, Types::Strict::String
-      attribute :user, Types::Strict::String
-      attribute :namespace, Types::Strict::String.optional.default(nil)
-      attribute :extensions, Types::Strict::Array.optional.default(nil)
+      attribute :cluster, Types::String
+      attribute :user, Types::String
+      attribute :namespace, Types::String.optional.default(nil)
+      attribute :extensions, Types::Array.optional.default(nil)
     end
 
     # named context
@@ -89,14 +89,14 @@ module K8s
       attribute :context, Context
     end
 
-    attribute :kind, Types::Strict::String.optional.default(nil)
-    attribute :apiVersion, Types::Strict::String.optional.default(nil)
-    attribute :preferences, Types::Strict::Hash.optional.default { {} }
-    attribute :clusters, Types::Strict::Array.of(NamedCluster).optional.default { [] }
-    attribute :users, Types::Strict::Array.of(NamedUser).optional.default { [] }
-    attribute :contexts, Types::Strict::Array.of(NamedContext).optional.default{ [] }
-    attribute :current_context, Types::Strict::String.optional.default(nil)
-    attribute :extensions, Types::Strict::Array.optional.default { [] }
+    attribute :kind, Types::String.optional.default(nil)
+    attribute :apiVersion, Types::String.optional.default(nil)
+    attribute :preferences, Types::Hash.optional.default { {} }
+    attribute :clusters, Types::Array.of(NamedCluster).optional.default { [] }
+    attribute :users, Types::Array.of(NamedUser).optional.default { [] }
+    attribute :contexts, Types::Array.of(NamedContext).optional.default{ [] }
+    attribute :current_context, Types::String.optional.default(nil)
+    attribute :extensions, Types::Array.optional.default { [] }
 
     # Loads a configuration from a YAML file
     #

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -163,10 +163,10 @@ module K8s
           logger.info "Delete resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace}"
           begin
             client.delete_resource(resource, propagationPolicy: 'Background')
-          rescue K8s::Error::NotFound => ex
+          rescue K8s::Error::NotFound => e
             # assume aliased objects in multiple API groups, like for Deployments
             # alternatively, a custom resource whose definition was already deleted earlier
-            logger.debug { "Ignoring #{ex} : #{ex.message}" }
+            logger.debug { "Ignoring #{e} : #{e.message}" }
           end
         end
       end

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -246,8 +246,8 @@ module K8s
       t = Time.now - start
 
       obj = options[:response_block] ? {} : parse_response(response, options, response_class: response_class)
-    rescue K8s::Error::API => exc
-      logger.warn { "#{format_request(options)} => HTTP #{exc.code} #{exc.reason} in #{'%.3f' % t}s" }
+    rescue K8s::Error::API => e
+      logger.warn { "#{format_request(options)} => HTTP #{e.code} #{e.reason} in #{'%.3f' % t}s" }
       logger.debug { "Request: #{excon_options[:body]}" } if excon_options[:body]
       logger.debug { "Response: #{response.body}" }
       raise
@@ -287,17 +287,17 @@ module K8s
           raise unless skip_forbidden
 
           nil
-        rescue K8s::Error::ServiceUnavailable => exc
+        rescue K8s::Error::ServiceUnavailable => e
           raise unless retry_errors
 
-          logger.warn { "Retry #{format_request(request_options)} => HTTP #{exc.code} #{exc.reason} in #{'%.3f' % t}s" }
+          logger.warn { "Retry #{format_request(request_options)} => HTTP #{e.code} #{e.reason} in #{'%.3f' % t}s" }
 
           # only retry the failed request, not the entire pipeline
           request(response_class: response_class, **common_options.merge(request_options))
         end
       }
-    rescue K8s::Error => exc
-      logger.warn { "[#{options.map{ |o| format_request(o) }.join ', '}] => HTTP #{exc.code} #{exc.reason} in #{'%.3f' % t}s" }
+    rescue K8s::Error => e
+      logger.warn { "[#{options.map{ |o| format_request(o) }.join ', '}] => HTTP #{e.code} #{e.reason} in #{'%.3f' % t}s" }
       raise
     else
       logger.info { "[#{options.map{ |o| format_request(o) }.join ', '}] => HTTP [#{responses.map(&:status).join ', '}] in #{'%.3f' % t}s" }


### PR DESCRIPTION
Fixes #106 

There seems to be some dry version incompatibilities that make the specs fail.

Upgrading brings a bunch of deprecation messages and warnings (some of which were actually helpful to spot the shared array instance defaults).

`include Dry::Types` has been deprecated and should now be `include Dry.Types()`, which by default brings Strict types. 
