### PR TITLE
Implement user.exec auth support

### DIFF
--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -49,6 +49,14 @@ module K8s
       attribute :config, Types::Hash
     end
 
+    # structured user exec
+    class UserExec < ConfigStruct
+      attribute :command, Types::String
+      attribute :apiVersion, Types::String
+      attribute :env, Types::Array.of(Types::Hash).optional.default(nil)
+      attribute :args, Types::Array.of(Types::String).optional.default(nil)
+    end
+
     # structured user
     class User < ConfigStruct
       attribute :client_certificate, Types::String.optional.default(nil)
@@ -63,7 +71,7 @@ module K8s
       attribute :username, Types::String.optional.default(nil)
       attribute :password, Types::String.optional.default(nil)
       attribute :auth_provider, UserAuthProvider.optional.default(nil)
-      attribute :exec, Types::Hash.optional.default(nil)
+      attribute :exec, UserExec.optional.default(nil)
       attribute :extensions, Types::Array.optional.default(nil)
     end
 

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -75,19 +75,44 @@ module K8s
         options[:auth_token] = token
       elsif config.user.auth_provider && auth_provider = config.user.auth_provider.config
         logger.debug "Using config with .user.auth-provider.name=#{config.user.auth_provider.name}"
-
-        auth_data = `#{auth_provider['cmd-path']} #{auth_provider['cmd-args']}`.strip
-        if auth_provider['token-key']
-          json_path = JsonPath.new(auth_provider['token-key'][1...-1])
-          options[:auth_token] = json_path.first(auth_data)
-        else
-          options[:auth_token] = auth_data
-        end
+        options[:auth_token] = token_from_auth_provider(auth_provider)
+      elsif exec_conf = config.user.exec
+        logger.debug "Using config with .user.exec.command=#{exec_conf.command}"
+        options[:auth_token] = token_from_exec(exec_conf)
       end
 
       logger.info "Using config with server=#{server}"
 
       new(server, **options, **overrides)
+    end
+
+    # @param auth_provider [K8s::Config::UserAuthProvider]
+    # @return [String]
+    def self.token_from_auth_provider(auth_provider)
+      auth_data = %x(#{auth_provider['cmd-path']} #{auth_provider['cmd-args']}).strip
+      if auth_provider['token-key']
+        json_path = JsonPath.new(auth_provider['token-key'][1...-1])
+        json_path.first(auth_data)
+      else
+        auth_data
+      end
+    end
+
+    # @param exec_conf [K8s::Config::UserExec]
+    # @return [String]
+    def self.token_from_exec(exec_conf)
+      cmd = [exec_conf.command]
+      cmd = cmd + exec_conf.args if exec_conf.args
+      orig_env = ENV.to_h
+      if envs = exec_conf.env
+        envs.each do |env|
+          ENV[env['name']] = env['value']
+        end
+      end
+      auth_token = %x(#{cmd.join(' ')}).strip
+      ENV.replace(orig_env)
+
+      auth_token
     end
 
     # In-cluster config within a kube pod, using the kubernetes service envs and serviceaccount secrets

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -114,10 +114,10 @@ module K8s
           ENV[env['name']] = env['value']
         end
       end
-      auth_token = %x(#{cmd.join(' ')}).strip
+      auth_json = %x(#{cmd.join(' ')}).strip
       ENV.replace(orig_env)
 
-      auth_token
+      JSON.parse(auth_json).dig('status', 'token')
     end
 
     # In-cluster config within a kube pod, using the kubernetes service envs and serviceaccount secrets

--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -94,7 +94,7 @@ module K8s
     # @param auth_provider [K8s::Config::UserAuthProvider]
     # @return [String]
     def self.token_from_auth_provider(auth_provider)
-      auth_data = %x(#{auth_provider['cmd-path']} #{auth_provider['cmd-args']}).strip
+      auth_data = `#{auth_provider['cmd-path']} #{auth_provider['cmd-args']}`.strip
       if auth_provider['token-key']
         json_path = JsonPath.new(auth_provider['token-key'][1...-1])
         json_path.first(auth_data)
@@ -107,14 +107,14 @@ module K8s
     # @return [String]
     def self.token_from_exec(exec_conf)
       cmd = [exec_conf.command]
-      cmd = cmd + exec_conf.args if exec_conf.args
+      cmd += exec_conf.args if exec_conf.args
       orig_env = ENV.to_h
       if envs = exec_conf.env
         envs.each do |env|
           ENV[env['name']] = env['value']
         end
       end
-      auth_json = %x(#{cmd.join(' ')}).strip
+      auth_json = `#{cmd.join(' ')}`.strip
       ENV.replace(orig_env)
 
       JSON.parse(auth_json).dig('status', 'token')

--- a/spec/fixtures/config/kubeconfig_user_exec_data.json
+++ b/spec/fixtures/config/kubeconfig_user_exec_data.json
@@ -1,0 +1,7 @@
+{
+    "apiVersion": "client.authentication.k8s.io/v1beta1",
+    "kind": "ExecCredential",
+    "status": {
+      "token": "my-bearer-token"
+    }
+  }

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -164,7 +164,59 @@ RSpec.describe K8s::Transport do
     end
   end
 
+  context 'for a kubeconfig using auth-provider' do
+    let(:config) { K8s::Config.new(
+      clusters: [
+        {
+          name: 'kubernetes',
+          cluster: {
+            server: 'http://localhost:8080',
+            certificate_authority: 'ca.pem',
 
+          }
+        }
+      ],
+      users: [
+        {
+          name: 'test',
+          user: {
+            exec: {
+              apiVersion: 'client.authentication.k8s.io/v1beta1',
+              command: 'echo',
+              args: [
+                'tokenz'
+              ]
+            }
+          }
+        }
+      ],
+
+      contexts: [
+        {
+          name: 'test',
+          context: {
+            cluster: 'kubernetes',
+            user: 'test'
+          }
+        }
+      ],
+      current_context: 'test'
+    ) }
+
+    subject { described_class.config(config) }
+
+    describe '#request_options' do
+      it "includes the Authorization token" do
+        expect(subject.request_options(method: 'GET', path: '/')).to eq({
+          method: 'GET',
+          path: '/',
+          headers: {
+            'Authorization' => 'Bearer tokenz',
+          },
+        })
+      end
+    end
+  end
 
   describe '#self.in_cluster_config' do
     context "with envs set" do

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -183,8 +183,11 @@ RSpec.describe K8s::Transport do
             exec: {
               apiVersion: 'client.authentication.k8s.io/v1beta1',
               command: 'echo',
+              env: [
+                { 'name' => 'CUSTOM_ENV', 'value' => '123' }
+              ],
               args: [
-                'tokenz'
+                'tokenz${CUSTOM_ENV}'
               ]
             }
           }
@@ -211,7 +214,7 @@ RSpec.describe K8s::Transport do
           method: 'GET',
           path: '/',
           headers: {
-            'Authorization' => 'Bearer tokenz',
+            'Authorization' => 'Bearer tokenz123',
           },
         })
       end

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -231,12 +231,12 @@ RSpec.describe K8s::Transport do
           user: {
             exec: {
               apiVersion: 'client.authentication.k8s.io/v1beta1',
-              command: 'echo',
+              command: 'cat',
               env: [
                 { 'name' => 'CUSTOM_ENV', 'value' => '123' }
               ],
               args: [
-                'tokenz${CUSTOM_ENV}'
+                "#{fixture_path}/config/kubeconfig_user_exec_data.json"
               ]
             }
           }
@@ -263,7 +263,7 @@ RSpec.describe K8s::Transport do
           method: 'GET',
           path: '/',
           headers: {
-            'Authorization' => 'Bearer tokenz123',
+            'Authorization' => 'Bearer my-bearer-token',
           },
         })
       end

--- a/spec/k8s/transport_spec.rb
+++ b/spec/k8s/transport_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe K8s::Transport do
     end
   end
 
-  context 'for a kubeconfig using auth-provider' do
+  context 'for a kubeconfig using exec' do
     let(:config) { K8s::Config.new(
       clusters: [
         {


### PR DESCRIPTION
PR implements support for:

```yaml
users:
- name: my-user
  user:
    exec:
      # Command to execute. Required.
      command: "example-client-go-exec-plugin"

      # API version to use when decoding the ExecCredentials resource. Required.
      #
      # The API version returned by the plugin MUST match the version listed here.
      #
      # To integrate with tools that support multiple versions (such as client.authentication.k8s.io/v1alpha1),
      # set an environment variable or pass an argument to the tool that indicates which version the exec plugin expects.
      apiVersion: "client.authentication.k8s.io/v1beta1"

      # Environment variables to set when executing the plugin. Optional.
      env:
      - name: "FOO"
        value: "bar"

      # Arguments to pass when executing the plugin. Optional.
      args:
      - "arg1"
      - "arg2"
```