### PR TITLE
Rename Transport to Transport::Excon

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -17,14 +17,14 @@ require "k8s/error"
 require 'k8s/resource'
 require 'k8s/resource_client'
 require 'k8s/stack'
-require 'k8s/transport'
+require 'k8s/transport/excon'
 
 module K8s
   # @param server [String] http/s URL
-  # @param options [Hash] @see Transport.new
+  # @param (see K8s::Transport::Excon.new)
   # @return [K8s::Client]
   def self.client(server, **options)
-    Client.new(Transport.new(server, **options))
+    Client.new(Transport::Excon.new(server, **options))
   end
 
   # Top-level client wrapper.
@@ -32,25 +32,25 @@ module K8s
   # Offers access to {APIClient} and {ResourceClient} instances.
   class Client
     # @param config [Phraos::Kube::Config]
-    # @param namespace [String] @see #initialize
-    # @param options [Hash] @see Transport.config
+    # @param namespace [String] default namespace for all operations
+    # @param (see K8s::Transport::Excon.config)
     # @return [K8s::Client]
     def self.config(config, namespace: nil, **options)
       new(
-        Transport.config(config, **options),
+        Transport::Excon.config(config, **options),
         namespace: namespace
       )
     end
 
     # An K8s::Client instance from in-cluster config within a kube pod, using the kubernetes service envs and serviceaccount secrets
-    # @see K8s::Transport#in_cluster_config
+    # @see K8s::Transport::Excon.in_cluster_config
     #
     # @param namespace [String] default namespace for all operations
-    # @param options [Hash] options passed to transport, @see Transport#in_cluster_config
+    # @param options [Hash] options passed to transport, @see Transport::Excon.#in_cluster_config
     # @return [K8s::Client]
     # @raise [K8s::Error::Config,Errno::ENOENT,Errno::EACCES]
     def self.in_cluster_config(namespace: nil, **options)
-      new(Transport.in_cluster_config(**options), namespace: namespace)
+      new(Transport::Excon.in_cluster_config(**options), namespace: namespace)
     end
 
     # Attempts to create a K8s::Client instance automatically using environment variables, existing configuration

--- a/spec/k8s/api_client_spec.rb
+++ b/spec/k8s/api_client_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe K8s::APIClient do
   include FixtureHelpers
 
-  let(:transport) { K8s::Transport.new('http://localhost:8080') }
-  let(:transport_with_prefix) { K8s::Transport.new('http://localhost:8080/k8s/clusters/c-dnmgm') }
+  let(:transport) { K8s::Transport::Excon.new('http://localhost:8080') }
+  let(:transport_with_prefix) { K8s::Transport::Excon.new('http://localhost:8080/k8s/clusters/c-dnmgm') }
 
   context "for the v1 API" do
     subject { described_class.new(transport, 'v1') }

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe K8s::Client do
   end
 
   context "for a mocked API" do
-    let(:transport) { K8s::Transport.new('http://localhost:8080') }
+    let(:transport) { K8s::Transport::Excon.new('http://localhost:8080') }
 
     subject { described_class.new(transport) }
 

--- a/spec/k8s/resource_client_spec.rb
+++ b/spec/k8s/resource_client_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe K8s::ResourceClient do
   include FixtureHelpers
 
-  let(:transport) { K8s::Transport.new('http://localhost:8080') }
+  let(:transport) { K8s::Transport::Excon.new('http://localhost:8080') }
 
   context "for the nodes API" do
     let(:api_client) { K8s::APIClient.new(transport, 'v1') }

--- a/spec/k8s/transport/excon_spec.rb
+++ b/spec/k8s/transport/excon_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe K8s::Transport do
+RSpec.describe K8s::Transport::Excon do
   include FixtureHelpers
 
   describe '#self.config' do


### PR DESCRIPTION
The philosophy of Transport was to abstract the transport layer, but it's very Excon specific.

A bunch of the generic methods should probably go into `K8s::Transport`
