### PR TITLE
Use $stderr instead of STDERR as default error log target

### DIFF
--- a/lib/k8s/logging.rb
+++ b/lib/k8s/logging.rb
@@ -9,7 +9,7 @@ module K8s
   # Instances can optionally also use logger! to define a per-instance Logger using a custom prefix.
   module Logging
     # Default log target
-    LOG_TARGET = STDERR
+    LOG_TARGET = $stderr
 
     # Default log level: show warnings.
     #


### PR DESCRIPTION
Not nice to forcefully use the real STDERR.
