### PR TITLE
Replace Hash deep merge refinement with a method

### DIFF
--- a/lib/k8s/config.rb
+++ b/lib/k8s/config.rb
@@ -175,7 +175,6 @@ module K8s
           when NilClass
             new_value
           else
-            warn "key is #{key} old val is #{old_value.inspect} and new val is #{new_value.inspect}"
             old_value
           end
         end

--- a/lib/k8s/resource.rb
+++ b/lib/k8s/resource.rb
@@ -12,7 +12,6 @@ module K8s
     include Comparable
 
     using YAMLSafeLoadStream
-    using K8s::Util::HashDeepMerge
 
     # @param data [String]
     # @return [self]
@@ -66,13 +65,9 @@ module K8s
     # @param attrs [Hash, K8s::Resource]
     # @return [K8s::Resource]
     def merge(attrs)
-      # deep clone of attrs
-      h = to_hash
-
-      # merge in-place
-      h.deep_merge!(attrs.to_hash, overwrite_arrays: true, merge_nil_values: true)
-
-      self.class.new(h)
+      self.class.new(
+        Util.deep_merge(to_hash, attrs.to_hash, overwrite_arrays: true, merge_nil_values: true)
+      )
     end
 
     # @return [String]

--- a/lib/k8s/util.rb
+++ b/lib/k8s/util.rb
@@ -3,54 +3,53 @@
 module K8s
   # Miscellaneous helpers
   module Util
-    module HashDeepMerge
-      refine Hash do
-        # @param other [Hash]
-        # @param overwrite_arrays [Boolean] when encountering an array, replace the array with the new array
-        # @param union_arrays [Boolean] when encountering an array, use Array#union to combine with the existing array
-        # @param keep_existing [Boolean] prefer old value over new value
-        # @param merge_nil_values [Boolean] overwrite an existing value with a nil value
-        # @param merge_non_hash [Boolean] calls .merge on objects that respond to .merge
-        def deep_merge(other, overwrite_arrays: true, union_arrays: false, keep_existing: false, merge_nil_values: false, merge_non_hash: false)
-          merge(other) do |key, old_value, new_value|
-            case old_value
-            when Hash
-              raise "#{key} : #{new_value.class.name} can not be merged into a Hash" unless new_value.is_a?(Hash)
+    # Deep merge hashes
+    #
+    # @param input [Hash]
+    # @param other [Hash]
+    # @param overwrite_arrays [Boolean] when encountering an array, replace the array with the new array
+    # @param union_arrays [Boolean] when encountering an array, use Array#union to combine with the existing array
+    # @param keep_existing [Boolean] prefer old value over new value
+    # @param merge_nil_values [Boolean] overwrite an existing value with a nil value
+    # @param merge_non_hash [Boolean] calls .merge on objects that respond to .merge
+    def self.deep_merge(input, other, overwrite_arrays: true, union_arrays: false, keep_existing: false, merge_nil_values: false, merge_non_hash: false)
+      raise ArgumentError, "input expected to be Hash, was #{input.class.name}" unless input.is_a?(Hash)
+      raise ArgumentError, "other expected to be Hash, was #{other.class.name}" unless other.is_a?(Hash)
 
-              old_value.deep_merge(
-                new_value,
-                overwrite_arrays: overwrite_arrays,
-                union_arrays: union_arrays,
-                keep_existing: keep_existing,
-                merge_nil_values: merge_nil_values,
-                merge_non_hash: merge_non_hash
-              )
-            when Array
-              if overwrite_arrays
-                new_value
-              elsif union_arrays
-                raise "#{key} : #{new_value.class.name} can not be merged into an Array" unless new_value.is_a?(Array)
+      input.merge(other) do |key, old_value, new_value|
+        case old_value
+        when Hash
+          raise "#{key} : #{new_value.class.name} can not be merged into a Hash" unless new_value.is_a?(Hash)
 
-                old_value | new_value
-              else
-                old_value + new_value
-              end
-            else
-              if keep_existing
-                old_value
-              elsif new_value.nil? && merge_nil_values
-                nil
-              elsif merge_non_hash && old_value.respond_to?(:merge)
-                old_value.merge(new_value)
-              else
-                new_value.nil? ? old_value : new_value
-              end
-            end
+          deep_merge(
+            old_value,
+            new_value,
+            overwrite_arrays: overwrite_arrays,
+            union_arrays: union_arrays,
+            keep_existing: keep_existing,
+            merge_nil_values: merge_nil_values,
+            merge_non_hash: merge_non_hash
+          )
+        when Array
+          if overwrite_arrays
+            new_value
+          elsif union_arrays
+            raise "#{key} : #{new_value.class.name} can not be merged into an Array" unless new_value.is_a?(Array)
+
+            old_value | new_value
+          else
+            old_value + new_value
           end
-        end
-
-        def deep_merge!(other, **options)
-          replace(deep_merge(other, **options))
+        else
+          if keep_existing
+            old_value
+          elsif new_value.nil? && merge_nil_values
+            nil
+          elsif merge_non_hash && old_value.respond_to?(:merge)
+            old_value.merge(new_value)
+          else
+            new_value.nil? ? old_value : new_value
+          end
         end
       end
     end

--- a/spec/k8s/util_spec.rb
+++ b/spec/k8s/util_spec.rb
@@ -1,73 +1,73 @@
 RSpec.describe K8s::Util do
-  describe K8s::Util::HashDeepMerge do
-    using K8s::Util::HashDeepMerge
+  describe "#deep_merge" do
+    let(:hash1) { { 'foo' => { 'bar' => { 'baz' => 'dog' } } } }
+    let(:hash2) { { 'foo' => { 'bar' => { 'buzz' => 'aldrin' } } } }
+    let(:options) { {} }
+
+    subject { described_class.deep_merge(hash1, hash2, **options) }
 
     it 'deep merges hashes inside hashes' do
-      expect(
-        { 'foo' => { 'bar' => { 'baz' => 'dog' } } }.deep_merge(
-        { 'foo' => { 'bar' => { 'buzz' => 'aldrin' } } }
-        )
-      ).to eq(
+      expect(subject).to eq(
         { 'foo' => { 'bar' => { 'baz' => 'dog', 'buzz' => 'aldrin' } } }
       )
     end
 
     describe 'overwrite_arrays: true' do
+      let(:hash1) { { 'foo' => { 'bar' => [ 'baz' ] } } }
+      let(:hash2) { { 'foo' => { 'bar' => [ 'dog' ] } } }
+      let(:options) { { overwrite_arrays: true } }
+
       it 'replaces arrays with new arrays' do
-        expect(
-          { 'foo' => { 'bar' => [ 'baz' ] } }.deep_merge(
-          { 'foo' => { 'bar' => [ 'dog' ] } }, overwrite_arrays: true
-          )
-        ).to eq(
+        expect(subject).to eq(
           { 'foo' => { 'bar' => [ 'dog' ] } }
         )
       end
     end
 
     describe 'overwrite_arrays: false, union_arrays: true' do
+      let(:hash1) { { 'foo' => { 'bar' => [ 'baz', 'cat' ] } } }
+      let(:hash2) { { 'foo' => { 'bar' => [ 'dog', 'baz' ] } } }
+      let(:options) { { overwrite_arrays: false, union_arrays: true } }
+
       it 'creates array union with new array' do
-        expect(
-          { 'foo' => { 'bar' => [ 'baz', 'cat' ] } }.deep_merge(
-          { 'foo' => { 'bar' => [ 'dog', 'baz' ] } }, overwrite_arrays: false, union_arrays: true
-          )
-        ).to eq(
+        expect(subject).to eq (
           { 'foo' => { 'bar' => [ 'baz', 'cat', 'dog' ] } }
         )
       end
     end
 
     describe 'overwrite_arrays: false, union_arrays: false' do
+      let(:hash1) { { 'foo' => { 'bar' => [ 'baz' ] } } }
+      let(:hash2) { { 'foo' => { 'bar' => [ 'dog', 'baz' ] } } }
+      let(:options) { { overwrite_arrays: false, union_arrays: false } }
+
       it 'combines arrays' do
-        expect(
-          { 'foo' => { 'bar' => [ 'baz' ] } }.deep_merge(
-          { 'foo' => { 'bar' => [ 'dog', 'baz' ] } }, overwrite_arrays: false, union_arrays: false
-          )
-        ).to eq(
+        expect(subject).to eq(
           { 'foo' => { 'bar' => [ 'baz', 'dog', 'baz' ] } }
         )
       end
     end
 
     describe 'keep_existing:' do
+      let(:hash1) { { 'foo' => { 'bar' => 'baz' } } }
+      let(:hash2) { { 'foo' => { 'bar' => 'dog' } } }
+      let(:options) { { keep_existing: keep_existing } }
+
       context 'true' do
+        let(:keep_existing) { true }
+
         it 'keeps existing values' do
-          expect(
-            { 'foo' => { 'bar' => 'baz' } }.deep_merge(
-            { 'foo' => { 'bar' => 'dog' } }, keep_existing: true
-            )
-          ).to eq(
+          expect(subject).to eq(
             { 'foo' => { 'bar' => 'baz' } }
           )
         end
       end
 
       context 'false' do
+        let(:keep_existing) { false }
+
         it 'replaces existing values' do
-          expect(
-            { 'foo' => { 'bar' => 'baz' } }.deep_merge(
-            { 'foo' => { 'bar' => 'dog' } }, keep_existing: false
-            )
-          ).to eq(
+          expect(subject).to eq(
             { 'foo' => { 'bar' => 'dog' } }
           )
         end
@@ -75,25 +75,25 @@ RSpec.describe K8s::Util do
     end
 
     describe 'merge_nil_values' do
+      let(:hash1) { { 'foo' => { 'bar' => 'baz' } } }
+      let(:hash2) { { 'foo' => { 'bar' => nil } } }
+      let(:options) { { merge_nil_values: merge_nil_values } }
+
       context 'false' do
+        let(:merge_nil_values) { false }
+
         it 'does not replace existing values with nils' do
-          expect(
-            { 'foo' => { 'bar' => 'baz' } }.deep_merge(
-            { 'foo' => { 'bar' => nil } }, merge_nil_values: false
-            )
-          ).to eq(
+          expect(subject).to eq(
             { 'foo' => { 'bar' => 'baz' } }
           )
         end
       end
 
       context 'true' do
+        let(:merge_nil_values) { true }
+
         it 'replaces existing values with nils' do
-          expect(
-            { 'foo' => { 'bar' => 'baz' } }.deep_merge(
-            { 'foo' => { 'bar' => nil } }, merge_nil_values: true
-            )
-          ).to eq(
+          expect(subject).to eq(
             { 'foo' => { 'bar' => nil } }
           )
         end


### PR DESCRIPTION
Refinements are weird.

Refactored `K8s::Util::HashDeepMerge` into `K8s::Util.deep_merge`.

Also removed a debug puts / warn from `K8s::Config` which for some reason now manifested itself.
