### PR TITLE
PUT updates if needed annotations missing

### DIFF
--- a/lib/k8s/foo.yaml
+++ b/lib/k8s/foo.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+  - name: myapp
+    image: docker.io/nginx/:1-alpine
+    resources:
+      limits:
+        memory: "10Mi"
+        cpu: "100m"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+  labels: {}
+spec:
+  containers:
+  - name: myapp
+    image: docker.io/nginx/:1-alpine
+    resources:
+      limits:
+        memory: "10Mi"
+        cpu: "100m"
+    ports: []
+
+
+
+

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -101,7 +101,7 @@ module K8s
         if !server_resource
           logger.info "Create resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           keep_resource! client.create_resource(prepare_resource(resource))
-        elsif server_resource.metadata.annotations[@checksum_annotation] != resource.checksum
+        elsif server_resource.metadata.annotations&.dig(@checksum_annotation) != resource.checksum
           logger.info "Update resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           r = prepare_resource(resource)
           if server_resource.can_patch?(@last_config_annotation)

--- a/spec/k8s/stack_spec.rb
+++ b/spec/k8s/stack_spec.rb
@@ -123,6 +123,17 @@ RSpec.describe K8s::Stack do
         }
         subject.apply(client, prune: false)
       end
+
+      it "updates the needed resource even when annotations missing" do
+        returned_resources = resources.dup
+        returned_resources = returned_resources.map { |r| subject.prepare_resource(r) unless r.nil? }
+        returned_resources[0].metadata.annotations = nil
+        allow(client).to receive(:get_resources).with([K8s::Resource, K8s::Resource, K8s::Resource]).and_return(returned_resources)
+
+        subject.resources[0] = subject.resources[0].merge(metadata: { labels: {'foo' => 'bar'}})
+        expect(client).to receive(:update_resource) { |r| r }
+        subject.apply(client, prune: false)
+      end
     end
 
     context "prunes namespaced objects first" do


### PR DESCRIPTION
If user has removed al k8s-client managed annotations, the stack apply failed with:
```
Error: undefined method `[]' for nil:NilClass
    /__enclose_io_memfs__/lib/ruby/gems/2.5.0/gems/k8s-client-0.8.3/lib/k8s/stack.rb:104:in `block in apply'
    /__enclose_io_memfs__/lib/ruby/gems/2.5.0/gems/k8s-client-0.8.3/lib/k8s/stack.rb:100:in `map'
    /__enclose_io_memfs__/lib/ruby/gems/2.5.0/gems/k8s-client-0.8.3/lib/k8s/stack.rb:100:in `apply'
```

