### PR TITLE
Release v0.10.1

### DIFF
--- a/lib/k8s/client/version.rb
+++ b/lib/k8s/client/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Client
     # Updated on releases using semver.
-    VERSION = "0.10.0"
+    VERSION = "0.10.1"
   end
 end


### PR DESCRIPTION
- PUT updates if needed annotations missing (#130)
- Fail gracefully when server sends no Content-Type header (#132)
- Handle semver build metadata/pre-release info (#134)