### PR TITLE
Release 0.10.2

### DIFF
--- a/lib/k8s/client/version.rb
+++ b/lib/k8s/client/version.rb
@@ -3,6 +3,6 @@
 module K8s
   class Client
     # Updated on releases using semver.
-    VERSION = "0.10.1"
+    VERSION = "0.10.2"
   end
 end


### PR DESCRIPTION
* Update excon to 0.64 #139
* Use `$stderr` instead of `STDERR` as default error log target #124
