### PR TITLE
Update excon to 0.66

### DIFF
--- a/k8s-client.gemspec
+++ b/k8s-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '~> 2.4'
 
-  spec.add_runtime_dependency "excon", "~> 0.64.0"
+  spec.add_runtime_dependency "excon", "~> 0.66"
   spec.add_runtime_dependency "dry-struct", "~> 0.5.0"
   spec.add_runtime_dependency "dry-types", "~> 0.13.0"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.0"


### PR DESCRIPTION
I think the bundled certificates were missing from 0.64 : https://github.com/excon/excon/commit/e226dad7a55003b5f59aec282cf4e2a10c0cb4bb

