### PR TITLE
Add kube node config files to autoconfig search paths

### DIFF
--- a/lib/k8s/client.rb
+++ b/lib/k8s/client.rb
@@ -82,8 +82,14 @@ module K8s
         configuration = K8s::Config.build(server: ENV['KUBE_SERVER'], ca: ENV['KUBE_CA'], auth_token: token)
       elsif !ENV['KUBECONFIG'].to_s.empty?
         configuration = K8s::Config.from_kubeconfig_env(ENV['KUBECONFIG'])
-      elsif File.exist?(File.join(Dir.home, '.kube', 'config'))
-        configuration = K8s::Config.load_file(File.join(Dir.home, '.kube', 'config'))
+      else
+        found_config = [
+          File.join(Dir.home, '.kube', 'config'),
+          '/etc/kubernetes/admin.conf',
+          '/etc/kubernetes/kubelet.conf'
+        ].find { |f| File.exist?(f) && File.readable?(f) }
+
+        configuration = K8s::Config.load_file(found_config) if found_config
       end
 
       if configuration

--- a/spec/k8s/client_spec.rb
+++ b/spec/k8s/client_spec.rb
@@ -123,17 +123,23 @@ RSpec.describe K8s::Client do
       end
     end
 
-    context 'from default ~/.kube/config' do
-      it 'loads the file' do
-        expect(File).to receive(:exist?).with(default_kubeconfig_path).and_return(true)
-        expect(File).to receive(:read).with(default_kubeconfig_path).and_return(kubeconfig)
+    context 'from default file locations' do
+      before do
+        expect(File).to receive(:exist?).with(default_kubeconfig_path).and_return(false)
+        expect(File).to receive(:exist?).with('/etc/kubernetes/admin.conf').and_return(false)
+        expect(File).to receive(:exist?).with('/etc/kubernetes/kubelet.conf').and_return(true)
+        expect(File).to receive(:readable?).with('/etc/kubernetes/kubelet.conf').and_return(true)
+      end
+
+      it 'loads a file if found' do
+        expect(File).to receive(:read).with('/etc/kubernetes/kubelet.conf').and_return(kubeconfig)
         expect(subject.autoconfig).to be_a K8s::Client
       end
     end
 
     context 'from in_cluster_config' do
       before do
-        allow(File).to receive(:exist?).with(default_kubeconfig_path).and_return(false)
+        allow(File).to receive(:exist?).with(anything).and_return(false)
         stub_const("ENV", {})
       end
 


### PR DESCRIPTION
Fixes #150 

This will make `K8s::Client.autoconfig` work "out of the box" on a kubernetes node (with limited node access rights on a worker node though).

