### PR TITLE
Keep resources with ownerReference in stack prune

### DIFF
--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -101,7 +101,7 @@ module K8s
         if !server_resource
           logger.info "Create resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           keep_resource! client.create_resource(prepare_resource(resource))
-        elsif server_resource.metadata&.ownerReference
+        elsif server_resource.metadata&.ownerReference && !server_resource.metadata.ownerReference.empty?
           logger.info "Server resource #{server_resource.apiVersion}:#{server_resource.apiKind}/#{server_resource.metadata.name} in namespace #{server_resource.metadata.namespace} has an ownerReference and will be kept"
           keep_resource! server_resource
         elsif server_resource.metadata&.annotations&.dig(@checksum_annotation) != resource.checksum

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -101,9 +101,6 @@ module K8s
         if !server_resource
           logger.info "Create resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           keep_resource! client.create_resource(prepare_resource(resource))
-        elsif server_resource.metadata&.ownerReferences && !server_resource.metadata.ownerReferences.empty?
-          logger.info "Server resource #{server_resource.apiVersion}:#{server_resource.apiKind}/#{server_resource.metadata.name} in namespace #{server_resource.metadata.namespace} has an ownerReference and will be kept"
-          keep_resource! server_resource
         elsif server_resource.metadata&.annotations&.dig(@checksum_annotation) != resource.checksum
           logger.info "Update resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           r = prepare_resource(resource)
@@ -164,6 +161,8 @@ module K8s
 
         if resource_label != name
           # apiserver did not respect labelSelector
+        elsif resource.metadata&.ownerReferences && !resource.metadata.ownerReferences.empty?
+          logger.info "Server resource #{resource.apiVersion}:#{resource.apiKind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} has ownerReferences and will be kept"
         elsif keep_resources && keep_resource?(resource)
           # resource is up-to-date
         else

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -101,7 +101,7 @@ module K8s
         if !server_resource
           logger.info "Create resource #{resource.apiVersion}:#{resource.kind}/#{resource.metadata.name} in namespace #{resource.metadata.namespace} with checksum=#{resource.checksum}"
           keep_resource! client.create_resource(prepare_resource(resource))
-        elsif server_resource.metadata&.ownerReference && !server_resource.metadata.ownerReference.empty?
+        elsif server_resource.metadata&.ownerReferences && !server_resource.metadata.ownerReferences.empty?
           logger.info "Server resource #{server_resource.apiVersion}:#{server_resource.apiKind}/#{server_resource.metadata.name} in namespace #{server_resource.metadata.namespace} has an ownerReference and will be kept"
           keep_resource! server_resource
         elsif server_resource.metadata&.annotations&.dig(@checksum_annotation) != resource.checksum

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -135,7 +135,7 @@ module K8s
       keep_annotation = @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"]
       return false unless keep_annotation
 
-      keep == resource.metadata&.annotations&.dig(@checksum_annotation)
+      keep_annotation == resource.metadata&.annotations&.dig(@checksum_annotation)
     end
 
     # Delete all stack resources that were not applied

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -123,13 +123,21 @@ module K8s
     # @param resource [K8s::Resource]
     # @return [K8s::Resource]
     def keep_resource!(resource)
-      @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"] = resource.metadata&.annotations.dig(@checksum_annotation)
+      annotation = resource.metadata&.annotations&.dig(@checksum_annotation)
+      return nil unless annotation
+
+      @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"] = annotation
     end
 
     # @param resource [K8s::Resource]
     # @return [Boolean]
     def keep_resource?(resource)
-      @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"] == resource.metadata&.annotations&.dig(@checksum_annotation)
+      return true if resource.metadata&.ownerReference
+
+      keep = @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"]
+      return false unless keep
+
+      keep == resource.metadata&.annotations&.dig(@checksum_annotation)
     end
 
     # Delete all stack resources that were not applied

--- a/lib/k8s/stack.rb
+++ b/lib/k8s/stack.rb
@@ -126,7 +126,7 @@ module K8s
     # @param resource [K8s::Resource]
     # @return [K8s::Resource]
     def keep_resource!(resource)
-      @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"] = annotation
+      @keep_resources["#{resource.kind}:#{resource.metadata.name}@#{resource.metadata.namespace}"] = resource.metadata&.annotations.dig(@checksum_annotation)
     end
 
     # @param resource [K8s::Resource]


### PR DESCRIPTION
Server resources with non-empty `metadata.ownerReferences` will be left untouched during stack prune.

(needs to be backported to v0.10)
