### PR TITLE
Reraise Excon errors as K8s::Errors

### DIFF
--- a/lib/k8s/error.rb
+++ b/lib/k8s/error.rb
@@ -5,6 +5,10 @@ require 'forwardable'
 module K8s
   # Top-level class for all errors raised by this gem.
   class Error < StandardError
+    Transport = Class.new(Error).freeze
+    SSL = Class.new(Transport).freeze
+    Socket = Class.new(Transport).freeze
+
     # Kube API error, related to a HTTP response with a non-2xx code
     class API < Error
       extend Forwardable

--- a/lib/k8s/resource_client.rb
+++ b/lib/k8s/resource_client.rb
@@ -224,7 +224,6 @@ module K8s
     # @param resourceVersion [nil, String]
     # @param timeout [nil, Integer]
     # @yield [K8S::WatchEvent]
-    # @raise [Excon::Error]
     def watch(labelSelector: nil, fieldSelector: nil, resourceVersion: nil, timeout: nil, namespace: @namespace)
       method = 'GET'
       path = path(namespace: namespace)


### PR DESCRIPTION
Fixes #162 

User should not care / know about transport backend.

- `Excon::Error::Certificate` / `Excon::Errors::CertificateError` is raised as `K8s::Error::SSL`
- `Excon::Error::Socket` / `Excon::Errors::SocketError` is raised as `K8s::Error::Socket`
- Any unspecified (that were not already catched as `K8s::Error::API`, `K8s::Error::HTTP_STATUS_ERRORS`) Excon errors are reraised as `K8s::Error::Transport`.
- rescuing `K8s::Error::Transport` will also rescue from `::SSL` and `::Socket` as they are inherited from `::Transport`.


