### PR TITLE
removed bin/k8s_client reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Individual resources are returned as `K8s::Resource` instances, which provide at
 
 The different `K8s::Error::API` subclasses represent different HTTP response codes, such as `K8s::Error::NotFound` or `K8s::Error::Conflict`.
 
-See [`bin/k8s-client`](bin/k8s-client) for example code.
-
 ### Creating a client
 
 #### Unauthenticated client


### PR DESCRIPTION
the client executable was removed in https://github.com/kontena/k8s-client/commit/8bca242633d7d03d127c003a3a88aaf89976f776