### PR TITLE
Upgrade excon dependency to 0.71

### DIFF
--- a/k8s-client.gemspec
+++ b/k8s-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '~> 2.4'
 
-  spec.add_runtime_dependency "excon", "~> 0.66"
+  spec.add_runtime_dependency "excon", "~> 0.71"
   spec.add_runtime_dependency "dry-struct", "~> 0.5.0"
   spec.add_runtime_dependency "dry-types", "~> 0.13.0"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1.0"


### PR DESCRIPTION
Fixes a vulnerability where  left-over data on a timed-out socket would be read by the next connection.

Also updates the bundled certs.
